### PR TITLE
Upgrade to OpenSearch 3.0 and Fesen HTTP client 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
 		<suggest.version>15.0.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>2.19.0</fesen.httpclient.version>
+		<fesen.httpclient.version>3.0.0-SNAPSHOT</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>2.19.1</opensearch.version>
-		<opensearch.runner.version>2.19.1.0</opensearch.runner.version>
+		<opensearch.version>3.0.0</opensearch.version>
+		<opensearch.runner.version>3.0.0.0-SNAPSHOT</opensearch.runner.version>
 
 		<!-- Tomcat -->
 		<tomcat.version>10.1.40</tomcat.version>


### PR DESCRIPTION
This pull request updates dependency versions in the `pom.xml` file to align with the latest releases and snapshots.

Dependency updates:

* Updated `fesen.httpclient.version` from `2.19.0` to `3.0.0-SNAPSHOT`.
* Updated `opensearch.version` from `2.19.1` to `3.0.0`.
* Updated `opensearch.runner.version` from `2.19.1.0` to `3.0.0.0-SNAPSHOT`.