### PR TITLE
Update Maven schema, plugin configs, and repository URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-parent</artifactId>
@@ -32,7 +32,7 @@
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-parent.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-parent.git</developerConnection>
-		<url>https://github.com/codelibs/fess</url>
+		<url>https://github.com/codelibs/fess-parent</url>
 	</scm>
 	<properties>
 		<fess.version>15.0.0-SNAPSHOT</fess.version>
@@ -166,7 +166,16 @@
 						<charset>UTF-8</charset>
 						<locale>en_US</locale>
 						<source>17</source>
+						<legacyMode>true</legacyMode>
 					</configuration>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
@@ -189,10 +198,9 @@
 					<version>3.2.1</version><!-- https://issues.apache.org/jira/browse/MSOURCES-143 -->
 					<executions>
 						<execution>
-							<id>source-jar</id>
-							<phase>package</phase>
+							<id>attach-sources</id>
 							<goals>
-								<goal>jar</goal>
+								<goal>jar-no-fork</goal>
 							</goals>
 						</execution>
 					</executions>
@@ -326,9 +334,15 @@
 			<url>https://maven.codelibs.org/</url>
 		</pluginRepository>
 		<pluginRepository>
-			<id>oss.sonatype.org</id>
-			<name>oss.sonatype.org</name>
-			<url>https://oss.sonatype.org/content/groups/public/</url>
+			<id>central-portal-snapshots</id>
+			<name>Central Portal Snapshots</name>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<repositories>
@@ -338,19 +352,8 @@
 			<url>https://maven.codelibs.org/</url>
 		</repository>
 		<repository>
-			<id>public.oss.sonatype.org</id>
-			<name>oss.sonatype.org</name>
-			<url>https://oss.sonatype.org/content/groups/public/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>sonatype-nexus-snapshots</id>
-			<name>Sonatype Nexus Snapshots</name>
+			<id>central-portal-snapshots</id>
+			<name>Central Portal Snapshots</name>
 			<url>https://central.sonatype.com/repository/maven-snapshots</url>
 			<releases>
 				<enabled>false</enabled>


### PR DESCRIPTION
This pull request updates the `pom.xml` file with changes to improve Maven configuration, enhance compatibility, and update repository settings. The most important changes include updating schema locations, modifying SCM URLs, adding new plugin configurations, and replacing outdated repository definitions.

### Maven configuration updates:
* Updated the `xsi:schemaLocation` URL to use a secure HTTPS link (`https://maven.apache.org/xsd/maven-4.0.0.xsd`) for better compatibility and security. (`[pom.xmlL2-R2](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2-R2)`)
* Updated the SCM URL from `https://github.com/codelibs/fess` to `https://github.com/codelibs/fess-parent` to reflect the correct repository. (`[pom.xmlL35-R35](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L35-R35)`)

### Plugin enhancements:
* Added `<legacyMode>true</legacyMode>` to the Maven Javadoc plugin configuration to enable legacy mode. Also added an execution block to attach Javadocs during the build process. (`[pom.xmlR169-R178](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R169-R178)`)
* Updated the Maven Source plugin execution configuration by renaming the execution ID from `source-jar` to `attach-sources` and replacing the goal `jar` with `jar-no-fork` for improved build behavior. (`[pom.xmlL192-R203](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L192-R203)`)

### Repository updates:
* Replaced the outdated Sonatype OSS repository (`oss.sonatype.org`) with the `central-portal-snapshots` repository, which is configured to enable snapshots and disable releases. (`[[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L329-R345)`, `[[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L341-R356)`)