### PR TITLE
Update DbFlute version to 1.2.9 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<fess.version>15.0.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
-		<dbflute.version>1.2.8</dbflute.version>
+		<dbflute.version>1.2.9</dbflute.version>
 		<lastaflute.version>2.0.0</lastaflute.version>
 		<lasta.di.version>2.0.0</lasta.di.version>
 		<lasta.taglib.version>2.0.0</lasta.taglib.version>


### PR DESCRIPTION
This pull request updates the DBFlute framework version in the pom.xml file from 1.2.8 to 1.2.9.
This change ensures the application benefits from the latest improvements and bug fixes in DbFlute version 1.2.9.