### PR TITLE
Release version 15.0.0 by removing SNAPSHOT suffix from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<url>https://github.com/codelibs/fess-parent</url>
 	</scm>
 	<properties>
-		<fess.version>15.0.0-SNAPSHOT</fess.version>
+		<fess.version>15.0.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.2.9</dbflute.version>
@@ -46,11 +46,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.0.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.0.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.0.0</crawler.version>
+		<crawler.playwright.version>15.0.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.0.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.0.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.0.0</fesen.httpclient.version>


### PR DESCRIPTION
This update finalizes the release of version 15.0.0 by updating the version numbers of key dependencies and components in the pom.xml file from 15.0.0-SNAPSHOT to 15.0.0. This includes fess.version, crawler.version, crawler.playwright.version, and suggest.version.
