### PR TITLE
Update dependency versions for Tomcat, Groovy, Jackson, Lucene, and Playwright

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.40</tomcat.version>
+		<tomcat.version>10.1.43</tomcat.version>
 		<tomcat.boot.version>2.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
@@ -81,13 +81,13 @@
 		<curl4j.version>1.3.0</curl4j.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
-		<groovy.version>4.0.26</groovy.version>
+		<groovy.version>4.0.27</groovy.version>
 		<guava.version>33.4.8-jre</guava.version>
 		<handlebars.version>4.4.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
 		<icu4j.version>77.1</icu4j.version>
-		<jackson.version>2.19.0</jackson.version>
+		<jackson.version>2.19.1</jackson.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
@@ -109,13 +109,13 @@
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.21.0</log4j.version>
 		<log4j.ecs.version>1.6.0</log4j.ecs.version>
-		<lucene.version>9.12.1</lucene.version>
+		<lucene.version>10.2.1</lucene.version>
 		<microsoft.graph.version>5.80.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
 		<nekohtml.version>2.1.3</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.4</pdfbox.version>
-		<playwright.version>1.50.0</playwright.version>
+		<playwright.version>1.53.0</playwright.version>
 		<poi.version>5.4.0</poi.version>
 		<sai.version>0.2.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION

This PR updates several dependencies in the pom.xml to their latest compatible versions:

- Tomcat: 10.1.40 → 10.1.43
- Groovy: 4.0.26 → 4.0.27
- Jackson: 2.19.0 → 2.19.1
- Lucene: 9.12.1 → 10.2.1
- Playwright: 1.50.0 → 1.53.0

These updates aim to incorporate the latest security patches, performance improvements, and compatibility updates.