### PR TITLE
Upgrade Java source compatibility from 17 to 21 in Maven configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 						<docencoding>UTF-8</docencoding>
 						<charset>UTF-8</charset>
 						<locale>en_US</locale>
-						<source>17</source>
+						<source>21</source>
 						<legacyMode>true</legacyMode>
 					</configuration>
 					<executions>


### PR DESCRIPTION
This pull request updates the Java source version in the Maven pom.xml file from 17 to 21. This change ensures that the project is compiled using Java 21 features and compatibility. Make sure that all build environments and dependencies support Java 21 before merging.
