### PR TITLE
Add MSAL4J dependency and upgrade Microsoft Graph SDK to v6.47.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 
 		<!-- Partner Library -->
 		<adal4j.version>1.6.7</adal4j.version>
+		<msal4j.version>1.21.0</msal4j.version>
 		<asm.version>9.8</asm.version>
 		<azure.core.version>1.55.4</azure.core.version>
 		<azure.identity.version>1.16.3</azure.identity.version>
@@ -111,7 +112,7 @@
 		<log4j.version>2.21.0</log4j.version>
 		<log4j.ecs.version>1.6.0</log4j.ecs.version>
 		<lucene.version>10.2.1</lucene.version>
-		<microsoft.graph.version>5.80.0</microsoft.graph.version>
+		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
 		<nekohtml.version>2.1.3</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>


### PR DESCRIPTION
This change introduces the following updates to the Maven project configuration:

- Add a new property msal4j.version set to 1.21.0 for Microsoft Authentication Library for Java (MSAL4J).
- Bump the microsoft.graph.version property from 5.80.0 to 6.47.0 to align with the latest Microsoft Graph SDK.

These updates ensure that authentication flows can leverage the newer MSAL4J library and that the Graph SDK is kept up-to-date with the latest features and bug fixes. Please verify compatibility and run integration tests against any Graph API calls to catch any potential breaking changes.
