### PR TITLE
Update dependency versions in pom.xml for improved compatibility and security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,25 +71,25 @@
 		<azure.core.version>1.55.4</azure.core.version>
 		<azure.identity.version>1.16.3</azure.identity.version>
 		<azure.core.http.netty.version>1.15.3</azure.core.http.netty.version>
-		<bouncycastle.version>1.80</bouncycastle.version>
-		<commons.codec.version>1.18.0</commons.codec.version>
+		<bouncycastle.version>1.81</bouncycastle.version>
+		<commons.codec.version>1.19.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>
-		<commons.io.version>2.19.0</commons.io.version>
-		<commons.lang3.version>3.17.0</commons.lang3.version>
+		<commons.io.version>2.20.0</commons.io.version>
+		<commons.lang3.version>3.18.0</commons.lang3.version>
 		<commons.net.version>3.11.1</commons.net.version>
 		<commons.pool2.version>2.12.1</commons.pool2.version>
-		<commons.text.version>1.13.1</commons.text.version>
-		<corelib.version>0.6.0</corelib.version>
+		<commons.text.version>1.14.0</commons.text.version>
+		<corelib.version>0.7.0-SNAPSHOT</corelib.version>
 		<curl4j.version>1.3.0</curl4j.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
-		<groovy.version>4.0.27</groovy.version>
+		<groovy.version>4.0.28</groovy.version>
 		<guava.version>33.4.8-jre</guava.version>
 		<handlebars.version>4.4.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
 		<icu4j.version>77.1</icu4j.version>
-		<jackson.version>2.19.1</jackson.version>
+		<jackson.version>2.19.2</jackson.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
@@ -99,7 +99,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>2.1.40</jcifs.version>
+		<jcifs.version>2.2.0-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
@@ -117,7 +117,7 @@
 		<nekohtml.version>2.1.3</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.4</pdfbox.version>
-		<playwright.version>1.53.0</playwright.version>
+		<playwright.version>1.54.0</playwright.version>
 		<poi.version>5.4.0</poi.version>
 		<sai.version>0.2.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
This update includes version bumps for several dependencies in the pom.xml file to leverage newer features, bug fixes, and security improvements. The updated libraries include:

- Bouncy Castle: 1.80 → 1.81
- Commons Codec: 1.18.0 → 1.19.0
- Commons IO: 2.19.0 → 2.20.0
- Commons Lang3: 3.17.0 → 3.18.0
- Commons Text: 1.13.1 → 1.14.0
- Corelib: 0.6.0 → 0.7.0-SNAPSHOT
- Groovy: 4.0.27 → 4.0.28
- Jackson: 2.19.1 → 2.19.2
- JCIFS: 2.1.40 → 2.2.0-SNAPSHOT
- Playwright: 1.53.0 → 1.54.0

These changes help ensure the project stays current with upstream developments and avoids known issues in previous versions.