### PR TITLE
Update Eclipse formatter config to version 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<configFile>https://www.codelibs.org/assets/formatter/eclipse-formatter-1.0.xml</configFile>
+						<configFile>https://www.codelibs.org/assets/formatter/eclipse-formatter-1.1.xml</configFile>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
This change updates the Eclipse code formatter configuration in the Maven pom.xml file from version 1.0 to 1.1. The new version likely includes updated formatting rules or improvements aligned with the latest coding standards provided by the Codelibs project.
