### PR TITLE
Upgrade jcifs dependency version to 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>2.2.0-SNAPSHOT</jcifs.version>
+		<jcifs.version>3.0.0-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>


### PR DESCRIPTION

This PR updates the jcifs dependency version in pom.xml from 2.2.0-SNAPSHOT to 3.0.0-SNAPSHOT.
The upgrade may include bug fixes, performance improvements, or API changes provided by the newer version.