### PR TITLE
Update Azure SDK dependencies to latest patch versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
 		<adal4j.version>1.6.7</adal4j.version>
 		<msal4j.version>1.21.0</msal4j.version>
 		<asm.version>9.8</asm.version>
-		<azure.core.version>1.55.4</azure.core.version>
+		<azure.core.version>1.55.5</azure.core.version>
 		<azure.identity.version>1.16.3</azure.identity.version>
-		<azure.core.http.netty.version>1.15.3</azure.core.http.netty.version>
+		<azure.core.http.netty.version>1.15.12</azure.core.http.netty.version>
 		<bouncycastle.version>1.81</bouncycastle.version>
 		<commons.codec.version>1.19.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>


### PR DESCRIPTION
This PR updates the Azure SDK dependencies in pom.xml to the latest available patch versions:

- azure-core: 1.55.4 → 1.55.5
- azure-core-http-netty: 1.15.3 → 1.15.12

These updates include minor bug fixes and stability improvements provided by the Azure SDK team. No breaking changes are expected since this is a patch-level upgrade.