### PR TITLE
Update dependency versions in pom.xml (Fesen, OpenSearch, Tomcat, Corelib, JCIFS, Lucene)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,14 @@
 		<suggest.version>15.2.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.1.0</fesen.httpclient.version>
+		<fesen.httpclient.version>3.2.0</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.1.0</opensearch.version>
-		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
+		<opensearch.version>3.2.0</opensearch.version>
+		<opensearch.runner.version>3.2.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.43</tomcat.version>
+		<tomcat.version>10.1.44</tomcat.version>
 		<tomcat.boot.version>2.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
@@ -79,7 +79,7 @@
 		<commons.net.version>3.11.1</commons.net.version>
 		<commons.pool2.version>2.12.1</commons.pool2.version>
 		<commons.text.version>1.14.0</commons.text.version>
-		<corelib.version>0.7.0-SNAPSHOT</corelib.version>
+		<corelib.version>0.7.0</corelib.version>
 		<curl4j.version>1.3.0</curl4j.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
@@ -99,7 +99,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>3.0.0-SNAPSHOT</jcifs.version>
+		<jcifs.version>2.1.40</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
@@ -111,7 +111,7 @@
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.21.0</log4j.version>
 		<log4j.ecs.version>1.6.0</log4j.ecs.version>
-		<lucene.version>10.2.1</lucene.version>
+		<lucene.version>10.2.2</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
 		<nekohtml.version>2.1.3</nekohtml.version>


### PR DESCRIPTION
This pull request updates several dependency versions in the `pom.xml` file, primarily to keep the project up-to-date with the latest releases and improve stability. The changes include upgrades to Fesen, OpenSearch, Tomcat, Lucene, and other libraries, as well as switching some dependencies from snapshot to stable releases.

Dependency version upgrades:

* Updated `fesen.httpclient.version`, `opensearch.version`, and `opensearch.runner.version` to 3.2.0, ensuring compatibility with the latest Fesen and OpenSearch releases.
* Upgraded `tomcat.version` from 10.1.43 to 10.1.44 for improved security and bug fixes.
* Updated `lucene.version` from 10.2.1 to 10.2.2 for the latest search library improvements.

Switch to stable releases:

* Changed `corelib.version` from `0.7.0-SNAPSHOT` to `0.7.0`, moving from a snapshot to a stable release for better reliability.
* Downgraded `jcifs.version` from `3.0.0-SNAPSHOT` to `2.1.40`, opting for a stable version instead of a snapshot.