### PR TITLE
Release version 15.2.0 by updating dependency versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.2.0-SNAPSHOT</fess.version>
+		<fess.version>15.2.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.2.9</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.2.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.2.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.2.0</crawler.version>
+		<crawler.playwright.version>15.2.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.2.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.2.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.2.0</fesen.httpclient.version>


### PR DESCRIPTION

This update finalizes the release of version 15.2.0 by removing -SNAPSHOT suffixes from the following dependencies in pom.xml:

- fess.version
- crawler.version
- crawler.playwright.version
- suggest.version

These changes promote the project from snapshot to stable release versions, ensuring consistency across dependencies.