### PR TITLE
Bump project and dependency versions to 15.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-parent</artifactId>
-	<version>15.2.1-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.2.0</fess.version>
+		<fess.version>15.3.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.2.9</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.2.0</crawler.version>
-		<crawler.playwright.version>15.2.0</crawler.playwright.version>
+		<crawler.version>15.3.0-SNAPSHOT</crawler.version>
+		<crawler.playwright.version>15.3.0-SNAPSHOT</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.2.0</suggest.version>
+		<suggest.version>15.3.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.2.0</fesen.httpclient.version>
@@ -114,7 +114,7 @@
 		<lucene.version>10.2.2</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
-		<nekohtml.version>2.1.3</nekohtml.version>
+		<nekohtml.version>3.0.0-SNAPSHOT</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.4</pdfbox.version>
 		<playwright.version>1.54.0</playwright.version>


### PR DESCRIPTION
This pull request updates the project version and several dependency versions in the `pom.xml` file to their respective `15.3.0-SNAPSHOT` or latest snapshot releases. These changes prepare the codebase for the next development cycle and ensure compatibility with the latest versions of core modules and dependencies.

Version updates for project and core modules:

* Project version in `pom.xml` updated from `15.2.1-SNAPSHOT` to `15.3.0-SNAPSHOT` to mark the start of the new development iteration.
* Core module properties (`fess.version`, `crawler.version`, `crawler.playwright.version`, and `suggest.version`) updated to `15.3.0-SNAPSHOT` for consistency across the platform. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R39) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L50-R54)

Dependency update:

* `nekohtml.version` updated from `2.1.3` to `3.0.0-SNAPSHOT` to use the latest snapshot release of the NekoHTML library.