### PR TITLE
Update jcifs dependency to 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>2.1.40</jcifs.version>
+		<jcifs.version>3.0.0-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>


### PR DESCRIPTION
## Summary
I updated the jcifs dependency from version 2.1.40 to 3.0.0-SNAPSHOT to leverage the latest improvements in SMB/CIFS protocol support.

## Changes Made
- Updated `jcifs.version` property in pom.xml from 2.1.40 to 3.0.0-SNAPSHOT
- This change affects all Fess projects that inherit from this parent POM

## Testing
- The snapshot version should be tested thoroughly in development environments before merging
- Integration tests with SMB/CIFS functionality should be verified

## Breaking Changes
- Moving to a SNAPSHOT version may introduce instability
- The 3.0.0 version may have API changes compared to 2.1.x series

## Additional Notes
- This is a development snapshot version and should be updated to a stable release once 3.0.0 is officially released
- Projects using this parent POM will automatically inherit this dependency version update