### PR TITLE
deps: update multiple dependency versions to latest releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<fess.version>15.3.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
-		<dbflute.version>1.2.9</dbflute.version>
+		<dbflute.version>1.3.0</dbflute.version>
 		<lastaflute.version>2.0.0</lastaflute.version>
 		<lasta.di.version>2.0.0</lasta.di.version>
 		<lasta.taglib.version>2.0.0</lasta.taglib.version>
@@ -54,14 +54,14 @@
 		<suggest.version>15.3.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.2.0</fesen.httpclient.version>
+		<fesen.httpclient.version>3.3.0</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.2.0</opensearch.version>
-		<opensearch.runner.version>3.2.0.0</opensearch.runner.version>
+		<opensearch.version>3.3.0</opensearch.version>
+		<opensearch.runner.version>3.3.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.44</tomcat.version>
+		<tomcat.version>10.1.48</tomcat.version>
 		<tomcat.boot.version>2.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
@@ -75,8 +75,8 @@
 		<commons.codec.version>1.19.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>
 		<commons.io.version>2.20.0</commons.io.version>
-		<commons.lang3.version>3.18.0</commons.lang3.version>
-		<commons.net.version>3.11.1</commons.net.version>
+		<commons.lang3.version>3.19.0</commons.lang3.version>
+		<commons.net.version>3.12.0</commons.net.version>
 		<commons.pool2.version>2.12.1</commons.pool2.version>
 		<commons.text.version>1.14.0</commons.text.version>
 		<corelib.version>0.7.0</corelib.version>
@@ -84,7 +84,7 @@
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
 		<groovy.version>4.0.28</groovy.version>
-		<guava.version>33.4.8-jre</guava.version>
+		<guava.version>33.5.0-jre</guava.version>
 		<handlebars.version>4.4.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
@@ -111,19 +111,19 @@
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.21.0</log4j.version>
 		<log4j.ecs.version>1.6.0</log4j.ecs.version>
-		<lucene.version>10.2.2</lucene.version>
+		<lucene.version>10.3.1</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
 		<nekohtml.version>3.0.0-SNAPSHOT</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
-		<pdfbox.version>3.0.4</pdfbox.version>
-		<playwright.version>1.54.0</playwright.version>
-		<poi.version>5.4.0</poi.version>
+		<pdfbox.version>3.0.5</pdfbox.version>
+		<playwright.version>1.55.0</playwright.version>
+		<poi.version>5.4.1</poi.version>
 		<sai.version>0.3.0-SNAPSHOT</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.0</spnego.version>
 		<sqlite.version>3.42.0.0</sqlite.version>
-		<tika.version>3.1.0</tika.version>
+		<tika.version>3.2.3</tika.version>
 
 		<!-- Testing -->
 		<utflute.version>2.0.0</utflute.version>


### PR DESCRIPTION
## Summary
This PR updates multiple dependency versions in the project's pom.xml to their latest stable releases. The updates include core frameworks, search engine components, and various utility libraries that are critical to the project's functionality.

## Changes Made
Updated the following dependencies:

**Core Framework**
- DBFlute: 1.2.9 → 1.3.0

**Search Engine Components**
- Fesen HTTP Client: 3.2.0 → 3.3.0
- OpenSearch: 3.2.0 → 3.3.0
- OpenSearch Runner: 3.2.0.0 → 3.3.0.0
- Lucene: 10.2.2 → 10.3.1

**Application Server**
- Apache Tomcat: 10.1.44 → 10.1.48

**Apache Commons Libraries**
- Commons Lang3: 3.18.0 → 3.19.0
- Commons Net: 3.11.1 → 3.12.0

**Utility Libraries**
- Guava: 33.4.8-jre → 33.5.0-jre
- Apache PDFBox: 3.0.4 → 3.0.5
- Apache POI: 5.4.0 → 5.4.1
- Apache Tika: 3.1.0 → 3.2.3
- Playwright: 1.54.0 → 1.55.0

## Rationale
These updates bring bug fixes, performance improvements, and security patches from upstream projects. Keeping dependencies current helps maintain project security, stability, and access to the latest features.

## Testing
- Build verification needed to ensure all dependencies resolve correctly
- Existing test suite should be run to verify compatibility
- No API changes are expected in these minor/patch version updates

## Breaking Changes
None expected. All updates are minor or patch versions following semantic versioning.

## Additional Notes
This is a routine maintenance update. Please review the dependency changelog if specific version details are needed.