### PR TITLE
Release: Bump versions to 15.3.0 stable release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.3.0-SNAPSHOT</fess.version>
+		<fess.version>15.3.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.0</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.3.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.3.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.3.0</crawler.version>
+		<crawler.playwright.version>15.3.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.3.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.3.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.3.0</fesen.httpclient.version>
@@ -99,7 +99,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>3.0.0-SNAPSHOT</jcifs.version>
+		<jcifs.version>3.0.0</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
@@ -114,12 +114,12 @@
 		<lucene.version>10.3.1</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
-		<nekohtml.version>3.0.0-SNAPSHOT</nekohtml.version>
+		<nekohtml.version>3.0.0</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.5</pdfbox.version>
 		<playwright.version>1.55.0</playwright.version>
 		<poi.version>5.4.1</poi.version>
-		<sai.version>0.3.0-SNAPSHOT</sai.version>
+		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.0</spnego.version>
 		<sqlite.version>3.42.0.0</sqlite.version>


### PR DESCRIPTION
## Summary

This PR updates all Fess-related component versions and dependencies from SNAPSHOT to stable 15.3.0 release versions, finalizing the release preparation for Fess 15.3.0.

## Changes Made

Updated the following dependency versions in `pom.xml`:

**Fess Components:**
- `fess.version`: 15.3.0-SNAPSHOT → 15.3.0
- `crawler.version`: 15.3.0-SNAPSHOT → 15.3.0
- `crawler.playwright.version`: 15.3.0-SNAPSHOT → 15.3.0
- `suggest.version`: 15.3.0-SNAPSHOT → 15.3.0

**Third-party Dependencies:**
- `jcifs.version`: 3.0.0-SNAPSHOT → 3.0.0
- `nekohtml.version`: 3.0.0-SNAPSHOT → 3.0.0
- `sai.version`: 0.3.0-SNAPSHOT → 0.3.0

## Testing

This is a version bump to stable releases. All component dependencies have been promoted from SNAPSHOT to their corresponding stable versions.

## Breaking Changes

None. This is a standard release version update.

## Additional Notes

- This PR completes the version stabilization for the Fess 15.3.0 release
- All SNAPSHOT dependencies have been replaced with their stable counterparts
- Ready for tagging and release to Maven Central