### PR TITLE
chore: bump version to 15.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-parent</artifactId>
-	<version>15.3.2-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.3.1</fess.version>
+		<fess.version>15.4.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.0</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.3.0</crawler.version>
-		<crawler.playwright.version>15.3.0</crawler.playwright.version>
+		<crawler.version>15.4.0-SNAPSHOT</crawler.version>
+		<crawler.playwright.version>15.4.0-SNAPSHOT</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.3.0</suggest.version>
+		<suggest.version>15.4.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.3.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary

This PR updates the version numbers across the fess-parent POM to begin the 15.4.0 development cycle. All Fess ecosystem components are being bumped from their 15.3.x versions to 15.4.0-SNAPSHOT.

## Changes Made

- **fess-parent**: Updated from `15.3.2-SNAPSHOT` to `15.4.0-SNAPSHOT`
- **fess.version**: Updated from `15.3.1` to `15.4.0-SNAPSHOT`
- **crawler.version**: Updated from `15.3.0` to `15.4.0-SNAPSHOT`
- **crawler.playwright.version**: Updated from `15.3.0` to `15.4.0-SNAPSHOT`
- **suggest.version**: Updated from `15.3.0` to `15.4.0-SNAPSHOT`

## Purpose

This version bump prepares the parent POM for the next development iteration. The SNAPSHOT designation indicates this is for ongoing development work on the 15.4.0 release.

## Impact

- All child projects depending on fess-parent will inherit these updated version properties
- This change maintains version consistency across the Fess ecosystem
- No functional changes are introduced - this is purely a version management update

## Testing

- Verified POM syntax is valid
- Confirmed all version properties follow the project's versioning convention
- No build or compilation changes expected

## Additional Notes

This is a routine version management update following the completion of the 15.3.1 release. The updated SNAPSHOT versions will be used during the 15.4.0 development cycle.