### PR TITLE
deps: update versions to stable releases for 15.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.3.2-SNAPSHOT</fess.version>
+		<fess.version>15.3.2</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.0</dbflute.version>
@@ -47,8 +47,8 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.3.1-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.3.1-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.3.1</crawler.version>
+		<crawler.playwright.version>15.3.1</crawler.playwright.version>
 
 		<!-- Suggest -->
 		<suggest.version>15.3.0</suggest.version>
@@ -114,7 +114,7 @@
 		<lucene.version>10.3.1</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
-		<nekohtml.version>3.0.1-SNAPSHOT</nekohtml.version>
+		<nekohtml.version>3.0.1</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.5</pdfbox.version>
 		<playwright.version>1.55.0</playwright.version>


### PR DESCRIPTION
## Summary
- Update fess.version from 15.3.2-SNAPSHOT to 15.3.2
- Update crawler.version from 15.3.1-SNAPSHOT to 15.3.1
- Update crawler.playwright.version from 15.3.1-SNAPSHOT to 15.3.1
- Update nekohtml.version from 3.0.1-SNAPSHOT to 3.0.1

## Changes
This PR updates dependency versions from SNAPSHOT to stable releases in preparation for the 15.3.2 release.