### PR TITLE
deps: update dependencies to SNAPSHOT versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
 		<commons.net.version>3.12.0</commons.net.version>
 		<commons.pool2.version>2.12.1</commons.pool2.version>
 		<commons.text.version>1.14.0</commons.text.version>
-		<corelib.version>0.7.0</corelib.version>
-		<curl4j.version>1.3.0</curl4j.version>
+		<corelib.version>0.7.1-SNAPSHOT</corelib.version>
+		<curl4j.version>1.3.1-SNAPSHOT</curl4j.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
 		<groovy.version>4.0.28</groovy.version>
@@ -93,15 +93,15 @@
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
-		<java.saml.version>3.0.0</java.saml.version>
+		<java.saml.version>3.0.1-SNAPSHOT</java.saml.version>
 		<jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>3.0.0</jcifs.version>
+		<jcifs.version>3.0.1-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
-		<jhighlight.version>1.1.0</jhighlight.version>
+		<jhighlight.version>1.1.1-SNAPSHOT</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
 		<jna.version>5.13.0</jna.version>
 		<jodconverter.version>4.4.7</jodconverter.version>
@@ -114,14 +114,14 @@
 		<lucene.version>10.3.1</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
-		<nekohtml.version>3.0.1</nekohtml.version>
+		<nekohtml.version>3.0.2-SNAPSHOT</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<pdfbox.version>3.0.5</pdfbox.version>
 		<playwright.version>1.55.0</playwright.version>
 		<poi.version>5.4.1</poi.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<spnego.version>1.2.0</spnego.version>
+		<spnego.version>1.2.1-SNAPSHOT</spnego.version>
 		<sqlite.version>3.42.0.0</sqlite.version>
 		<tika.version>3.2.3</tika.version>
 


### PR DESCRIPTION
## Summary
- Updated 7 dependencies to their next SNAPSHOT versions for development
- corelib: 0.7.0 → 0.7.1-SNAPSHOT
- curl4j: 1.3.0 → 1.3.1-SNAPSHOT
- java.saml: 3.0.0 → 3.0.1-SNAPSHOT
- jcifs: 3.0.0 → 3.0.1-SNAPSHOT
- jhighlight: 1.1.0 → 1.1.1-SNAPSHOT
- nekohtml: 3.0.1 → 3.0.2-SNAPSHOT
- spnego: 1.2.0 → 1.2.1-SNAPSHOT

## Test plan
- [ ] Verify project builds successfully with updated dependencies
- [ ] Run existing test suite to ensure compatibility
- [ ] Check for any dependency conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)