### PR TITLE
deps: add dependency version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<azure.identity.version>1.16.3</azure.identity.version>
 		<azure.core.http.netty.version>1.15.12</azure.core.http.netty.version>
 		<bouncycastle.version>1.81</bouncycastle.version>
+		<commonmark.version>0.27.0</commonmark.version>
 		<commons.codec.version>1.19.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>
 		<commons.io.version>2.20.0</commons.io.version>
@@ -81,6 +82,7 @@
 		<commons.text.version>1.14.0</commons.text.version>
 		<corelib.version>0.7.1-SNAPSHOT</corelib.version>
 		<curl4j.version>1.3.1-SNAPSHOT</curl4j.version>
+		<google.cloud.storage.version>2.60.0</google.cloud.storage.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
 		<groovy.version>4.0.28</groovy.version>
@@ -119,6 +121,7 @@
 		<pdfbox.version>3.0.5</pdfbox.version>
 		<playwright.version>1.55.0</playwright.version>
 		<poi.version>5.4.1</poi.version>
+		<s3.version>2.40.5</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.1-SNAPSHOT</spnego.version>


### PR DESCRIPTION
## Summary
- Add `commonmark.version` property (0.27.0)
- Add `google.cloud.storage.version` property (2.60.0)
- Add `s3.version` property for AWS SDK (2.40.5)

## Test plan
- [ ] Verify Maven build succeeds with new version properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)