### PR TITLE
deps: update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,44 +54,44 @@
 		<suggest.version>15.4.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.3.0</fesen.httpclient.version>
+		<fesen.httpclient.version>3.4.0-SNAPSHOT</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.3.2</opensearch.version>
-		<opensearch.runner.version>3.3.2.0</opensearch.runner.version>
+		<opensearch.version>3.4.0</opensearch.version>
+		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.48</tomcat.version>
+		<tomcat.version>10.1.50</tomcat.version>
 		<tomcat.boot.version>2.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
 		<adal4j.version>1.6.7</adal4j.version>
 		<msal4j.version>1.21.0</msal4j.version>
-		<asm.version>9.8</asm.version>
+		<asm.version>9.9.1</asm.version>
 		<azure.core.version>1.55.5</azure.core.version>
 		<azure.identity.version>1.16.3</azure.identity.version>
 		<azure.core.http.netty.version>1.15.12</azure.core.http.netty.version>
-		<bouncycastle.version>1.81</bouncycastle.version>
+		<bouncycastle.version>1.83</bouncycastle.version>
 		<commonmark.version>0.27.0</commonmark.version>
-		<commons.codec.version>1.19.0</commons.codec.version>
+		<commons.codec.version>1.20.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>
-		<commons.io.version>2.20.0</commons.io.version>
-		<commons.lang3.version>3.19.0</commons.lang3.version>
+		<commons.io.version>2.21.0</commons.io.version>
+		<commons.lang3.version>3.20.0</commons.lang3.version>
 		<commons.net.version>3.12.0</commons.net.version>
-		<commons.pool2.version>2.12.1</commons.pool2.version>
-		<commons.text.version>1.14.0</commons.text.version>
+		<commons.pool2.version>2.13.0</commons.pool2.version>
+		<commons.text.version>1.15.0</commons.text.version>
 		<corelib.version>0.7.1-SNAPSHOT</corelib.version>
 		<curl4j.version>1.3.1-SNAPSHOT</curl4j.version>
 		<google.cloud.storage.version>2.60.0</google.cloud.storage.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
-		<groovy.version>4.0.28</groovy.version>
+		<groovy.version>4.0.29</groovy.version>
 		<guava.version>33.5.0-jre</guava.version>
 		<handlebars.version>4.4.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
-		<icu4j.version>77.1</icu4j.version>
-		<jackson.version>2.19.2</jackson.version>
+		<icu4j.version>78.1</icu4j.version>
+		<jackson.version>2.19.4</jackson.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
@@ -113,13 +113,13 @@
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.21.0</log4j.version>
 		<log4j.ecs.version>1.6.0</log4j.ecs.version>
-		<lucene.version>10.3.1</lucene.version>
+		<lucene.version>10.3.2</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
 		<minio.version>8.5.17</minio.version>
 		<nekohtml.version>3.0.2-SNAPSHOT</nekohtml.version>
 		<okhttp.version>4.12.0</okhttp.version>
-		<pdfbox.version>3.0.5</pdfbox.version>
-		<playwright.version>1.55.0</playwright.version>
+		<pdfbox.version>3.0.6</pdfbox.version>
+		<playwright.version>1.57.0</playwright.version>
 		<poi.version>5.4.1</poi.version>
 		<s3.version>2.40.5</s3.version>
 		<sai.version>0.3.0</sai.version>


### PR DESCRIPTION
## Summary
Update various dependency versions to their latest releases.

## Changes Made
- **OpenSearch**: 3.3.2 → 3.4.0
- **OpenSearch Runner**: 3.3.2.0 → 3.4.0.0
- **Fesen HTTP Client**: 3.3.0 → 3.4.0-SNAPSHOT
- **Tomcat**: 10.1.48 → 10.1.50
- **ASM**: 9.8 → 9.9.1
- **Bouncy Castle**: 1.81 → 1.83
- **Commons Codec**: 1.19.0 → 1.20.0
- **Commons IO**: 2.20.0 → 2.21.0
- **Commons Lang3**: 3.19.0 → 3.20.0
- **Commons Pool2**: 2.12.1 → 2.13.0
- **Commons Text**: 1.14.0 → 1.15.0
- **Groovy**: 4.0.28 → 4.0.29
- **ICU4J**: 77.1 → 78.1
- **Jackson**: 2.19.2 → 2.19.4
- **Lucene**: 10.3.1 → 10.3.2
- **PDFBox**: 3.0.5 → 3.0.6
- **Playwright**: 1.55.0 → 1.57.0

## Testing
- Parent POM changes - downstream projects will pick up new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)