### PR TITLE
deps: update dependencies to release versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.4.0-SNAPSHOT</fess.version>
+		<fess.version>15.4.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.0</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.4.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.4.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.4.0</crawler.version>
+		<crawler.playwright.version>15.4.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.4.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.4.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.4.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary

- Update Fess ecosystem dependencies from SNAPSHOT to 15.4.0 release versions

## Changes Made

- `fess.version`: 15.4.0-SNAPSHOT → 15.4.0
- `crawler.version`: 15.4.0-SNAPSHOT → 15.4.0
- `crawler.playwright.version`: 15.4.0-SNAPSHOT → 15.4.0
- `suggest.version`: 15.4.0-SNAPSHOT → 15.4.0

## Testing

- No code changes, only dependency version updates
- Downstream projects should be tested with the new release versions

## Additional Notes

This PR updates the parent POM to use the stable 15.4.0 release versions instead of SNAPSHOT versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)