### PR TITLE
deps: update utflute version to 2.5.0-A-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<tika.version>3.2.3</tika.version>
 
 		<!-- Testing -->
-		<utflute.version>2.0.0</utflute.version>
+		<utflute.version>2.5.0-A-SNAPSHOT</utflute.version>
 		<junit.version>4.13.2</junit.version>
 		<junit.jupiter.version>5.12.2</junit.jupiter.version>
 		<junit.vintage.version>5.12.2</junit.vintage.version>


### PR DESCRIPTION
## Summary

Update utflute testing framework version to the latest development snapshot.

## Changes Made

- Updated `utflute.version` from `2.0.0` to `2.5.0-A-SNAPSHOT` in pom.xml

## Testing

This is a dependency version update. Projects depending on fess-parent will pick up the new utflute version when building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)