### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<fess.version>15.5.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
-		<dbflute.version>1.3.0</dbflute.version>
+		<dbflute.version>1.3.1</dbflute.version>
 		<lastaflute.version>2.0.0</lastaflute.version>
 		<lasta.di.version>2.0.0</lasta.di.version>
 		<lasta.taglib.version>2.0.0</lasta.taglib.version>
@@ -51,17 +51,17 @@
 		<crawler.playwright.version>15.5.0-SNAPSHOT</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.4.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.5.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.4.0</fesen.httpclient.version>
+		<fesen.httpclient.version>3.5.0</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.4.0</opensearch.version>
-		<opensearch.runner.version>3.4.0.0</opensearch.runner.version>
+		<opensearch.version>3.5.0</opensearch.version>
+		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.50</tomcat.version>
+		<tomcat.version>10.1.52</tomcat.version>
 		<tomcat.boot.version>2.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
@@ -72,26 +72,28 @@
 		<azure.identity.version>1.16.3</azure.identity.version>
 		<azure.core.http.netty.version>1.15.12</azure.core.http.netty.version>
 		<bouncycastle.version>1.83</bouncycastle.version>
-		<commonmark.version>0.27.0</commonmark.version>
-		<commons.codec.version>1.20.0</commons.codec.version>
+		<commonmark.version>0.27.1</commonmark.version>
+		<commons.codec.version>1.21.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M2</commons.fileupload.version>
 		<commons.io.version>2.21.0</commons.io.version>
 		<commons.lang3.version>3.20.0</commons.lang3.version>
 		<commons.net.version>3.12.0</commons.net.version>
-		<commons.pool2.version>2.13.0</commons.pool2.version>
+		<commons.pool2.version>2.13.1</commons.pool2.version>
 		<commons.text.version>1.15.0</commons.text.version>
 		<corelib.version>0.7.1</corelib.version>
 		<curl4j.version>1.3.1</curl4j.version>
 		<google.cloud.storage.version>2.60.0</google.cloud.storage.version>
 		<google.http.client.version>1.44.2</google.http.client.version>
 		<google.oauth.client.version>1.36.0</google.oauth.client.version>
-		<groovy.version>4.0.29</groovy.version>
+		<groovy.version>4.0.30</groovy.version>
 		<guava.version>33.5.0-jre</guava.version>
 		<handlebars.version>4.4.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
-		<icu4j.version>78.1</icu4j.version>
-		<jackson.version>2.19.4</jackson.version>
+		<httpclient5.version>5.6</httpclient5.version>
+		<icu4j.version>78.2</icu4j.version>
+		<jackson.version>2.20.1</jackson.version>
+		<jackson.annotations.version>2.20</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<jakarta.activation.api.version>1.2.2</jakarta.activation.api.version>
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
@@ -101,7 +103,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>3.0.1</jcifs.version>
+		<jcifs.version>3.0.2-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.1</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
@@ -111,17 +113,17 @@
 		<jakarta.jstl.version>3.0.1</jakarta.jstl.version>
 		<jakarta.transaction.version>2.0.1</jakarta.transaction.version>
 		<kryo.version>5.6.2</kryo.version>
-		<log4j.version>2.21.0</log4j.version>
-		<log4j.ecs.version>1.6.0</log4j.ecs.version>
+		<log4j.version>2.25.3</log4j.version>
+		<log4j.ecs.version>1.7.0</log4j.ecs.version>
 		<lucene.version>10.3.2</lucene.version>
 		<microsoft.graph.version>6.47.0</microsoft.graph.version>
-		<minio.version>8.5.17</minio.version>
+		<minio.version>8.6.0</minio.version>
 		<nekohtml.version>3.0.2</nekohtml.version>
-		<okhttp.version>4.12.0</okhttp.version>
+		<okhttp.version>5.1.0</okhttp.version>
 		<pdfbox.version>3.0.6</pdfbox.version>
-		<playwright.version>1.57.0</playwright.version>
+		<playwright.version>1.58.0</playwright.version>
 		<poi.version>5.4.1</poi.version>
-		<s3.version>2.40.5</s3.version>
+		<s3.version>2.41.25</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.1</spnego.version>


### PR DESCRIPTION
## Summary
Update multiple dependency versions in the parent POM to their latest releases.

## Changes Made
- **dbflute**: 1.3.0 → 1.3.1
- **suggest**: 15.4.0-SNAPSHOT → 15.5.0-SNAPSHOT
- **fesen-httpclient**: 3.4.0 → 3.5.0
- **opensearch**: 3.4.0 → 3.5.0, runner 3.4.0.0 → 3.5.0.0
- **tomcat**: 10.1.50 → 10.1.52
- **commonmark**: 0.27.0 → 0.27.1
- **commons-codec**: 1.20.0 → 1.21.0
- **commons-pool2**: 2.13.0 → 2.13.1
- **groovy**: 4.0.29 → 4.0.30
- **icu4j**: 78.1 → 78.2
- **jackson**: 2.19.4 → 2.20.1 (added `jackson.annotations.version` 2.20)
- **jcifs**: 3.0.1 → 3.0.2-SNAPSHOT
- **log4j**: 2.21.0 → 2.25.3
- **log4j-ecs**: 1.6.0 → 1.7.0
- **minio**: 8.5.17 → 8.6.0
- **okhttp**: 4.12.0 → 5.1.0
- **playwright**: 1.57.0 → 1.58.0
- **s3**: 2.40.5 → 2.41.25
- Added new `httpclient5.version` property (5.6)

## Testing
- Downstream modules (fess, fess-crawler, fess-suggest) should be built against these updated versions to verify compatibility
- Pay special attention to the major version bumps: okhttp 4→5, jackson 2.19→2.20, log4j 2.21→2.25

## Breaking Changes
- **okhttp** 4.12.0 → 5.1.0 is a major version bump and may require API changes in downstream consumers
- **jackson** 2.19 → 2.20 may introduce behavioral changes

## Additional Notes
- The `jcifs` version is set to a SNAPSHOT (3.0.2-SNAPSHOT), which should be updated to a release version before the final release