### PR TITLE
Release 15.5.0: remove SNAPSHOT from dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.5.0-SNAPSHOT</fess.version>
+		<fess.version>15.5.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.5.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.5.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.5.0</crawler.version>
+		<crawler.playwright.version>15.5.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.5.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.5.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.5.0</fesen.httpclient.version>
@@ -103,7 +103,7 @@
 		<jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
-		<jcifs.version>3.0.2-SNAPSHOT</jcifs.version>
+		<jcifs.version>3.0.2</jcifs.version>
 		<jersey.common.version>3.1.3</jersey.common.version>
 		<jhighlight.version>1.1.1</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>


### PR DESCRIPTION
## Summary
- Remove `-SNAPSHOT` suffix from `fess.version` (15.5.0)
- Remove `-SNAPSHOT` suffix from `crawler.version` and `crawler.playwright.version` (15.5.0)
- Remove `-SNAPSHOT` suffix from `suggest.version` (15.5.0)
- Remove `-SNAPSHOT` suffix from `jcifs.version` (3.0.2)

## Test plan
- [ ] Verify `mvn clean install` succeeds with the release versions
- [ ] Confirm all referenced artifacts are available in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)