### PR TITLE
chore(deps): update Tomcat and Jakarta Annotation API versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>10.1.52</tomcat.version>
-		<tomcat.boot.version>2.0.0</tomcat.boot.version>
+		<tomcat.version>11.0.18</tomcat.version>
+		<tomcat.boot.version>3.0.0-A-SNAPSHOT</tomcat.boot.version>
 
 		<!-- Partner Library -->
 		<msal4j.version>1.24.0</msal4j.version>
@@ -95,7 +95,7 @@
 		<jackson.annotations.version>2.20</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<java.saml.version>3.0.1</java.saml.version>
-		<jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
+		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.3</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>


### PR DESCRIPTION
## Summary
Update Tomcat to version 11 and Jakarta Annotation API to version 3.0.0 in the parent POM.

## Changes Made
- Update `tomcat.version` from 10.1.52 to 11.0.18
- Update `tomcat.boot.version` from 2.0.0 to 3.0.0-A-SNAPSHOT
- Update `jakarta.annotation.api.version` from 2.1.1 to 3.0.0

## Breaking Changes
- Tomcat 11 is a major version upgrade from Tomcat 10.1, which may require changes in downstream projects
- Jakarta Annotation API 3.0.0 is a major version upgrade from 2.1.1
- tomcat.boot 3.0.0-A-SNAPSHOT is a snapshot release and may be unstable

## Additional Notes
- Downstream projects should be tested for compatibility with the new Tomcat 11 and Jakarta Annotation API 3.0.0 versions