### PR TITLE
Release Tomcat Boot version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
 		<!-- Tomcat -->
 		<tomcat.version>11.0.18</tomcat.version>
-		<tomcat.boot.version>3.0.0-A-SNAPSHOT</tomcat.boot.version>
+		<tomcat.boot.version>3.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
 		<msal4j.version>1.24.0</msal4j.version>


### PR DESCRIPTION
## Summary
Updates the Tomcat Boot dependency version from a snapshot release to the stable 3.0.0 release.

## Changes
- Updated `tomcat.boot.version` from `3.0.0-A-SNAPSHOT` to `3.0.0` in pom.xml

## Details
This change transitions the project from using a pre-release snapshot version of Tomcat Boot to the official 3.0.0 release, ensuring the application uses a stable, production-ready version of the dependency.

