### PR TITLE
chore(deps): update dependency versions for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,11 @@
 		<suggest.version>15.6.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.5.1-SNAPSHOT</fesen.httpclient.version>
+		<fesen.httpclient.version>3.6.0</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.5.0</opensearch.version>
-		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
+		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
 		<tomcat.version>11.0.18</tomcat.version>
@@ -80,7 +80,7 @@
 		<commons.pool2.version>2.13.1</commons.pool2.version>
 		<commons.text.version>1.15.0</commons.text.version>
 		<corelib.version>0.7.1</corelib.version>
-		<curl4j.version>1.3.2-SNAPSHOT</curl4j.version>
+		<curl4j.version>1.3.2</curl4j.version>
 		<google.cloud.storage.version>2.64.0</google.cloud.storage.version>
 		<google.http.client.version>1.47.0</google.http.client.version>
 		<google.oauth.client.version>1.39.0</google.oauth.client.version>
@@ -94,7 +94,7 @@
 		<jackson.version>2.20.1</jackson.version>
 		<jackson.annotations.version>2.20</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
-		<java.saml.version>3.1.0-SNAPSHOT</java.saml.version>
+		<java.saml.version>3.1.0</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.3</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
@@ -102,7 +102,7 @@
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
 		<jcifs.version>3.0.2</jcifs.version>
 		<jersey.common.version>3.1.10</jersey.common.version>
-		<jhighlight.version>2.0.0-SNAPSHOT</jhighlight.version>
+		<jhighlight.version>2.0.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
 		<jodconverter.version>4.4.9</jodconverter.version>
 		<jakarta.jstl.api.version>3.0.2</jakarta.jstl.api.version>


### PR DESCRIPTION
## Summary
Update dependency versions from SNAPSHOT to release versions and bump OpenSearch to 3.6.0.

## Changes Made
- `fesen.httpclient`: 3.5.1-SNAPSHOT → 3.6.0
- `opensearch`: 3.5.0 → 3.6.0
- `opensearch.runner`: 3.5.0.0 → 3.6.0.0
- `curl4j`: 1.3.2-SNAPSHOT → 1.3.2
- `java.saml`: 3.1.0-SNAPSHOT → 3.1.0
- `jhighlight`: 2.0.0-SNAPSHOT → 2.0.0

## Testing
- Build verification with updated dependencies

## Breaking Changes
- None

## Additional Notes
- SNAPSHOT versions promoted to release versions
- OpenSearch and fesen-httpclient bumped to 3.6.0