### PR TITLE
chore(deps): update versions for 15.6.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.6.0-SNAPSHOT</fess.version>
+		<fess.version>15.6.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.6.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.6.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.6.0</crawler.version>
+		<crawler.playwright.version>15.6.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.6.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.6.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.6.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary
Remove SNAPSHOT suffix from component versions to prepare for the 15.6.0 release.

## Changes Made
- Update `fess.version` from `15.6.0-SNAPSHOT` to `15.6.0`
- Update `crawler.version` from `15.6.0-SNAPSHOT` to `15.6.0`
- Update `crawler.playwright.version` from `15.6.0-SNAPSHOT` to `15.6.0`
- Update `suggest.version` from `15.6.0-SNAPSHOT` to `15.6.0`

## Testing
- Version property changes only; no functional code affected
- Downstream projects should verify dependency resolution after merge