### PR TITLE
Update version to 15.7.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-parent</artifactId>
-	<version>15.6.1-SNAPSHOT</version>
+	<version>15.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.6.0</fess.version>
+		<fess.version>15.7.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.6.0</crawler.version>
-		<crawler.playwright.version>15.6.0</crawler.playwright.version>
+		<crawler.version>15.7.0-SNAPSHOT</crawler.version>
+		<crawler.playwright.version>15.7.0-SNAPSHOT</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.6.0</suggest.version>
+		<suggest.version>15.7.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.6.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary

Bump fess-parent version for the 15.7.0 development cycle.

- Project version: `15.6.1-SNAPSHOT` → `15.7.0-SNAPSHOT`
- `fess.version`: `15.6.0` → `15.7.0-SNAPSHOT`
- `crawler.version`: `15.6.0` → `15.7.0-SNAPSHOT`
- `crawler.playwright.version`: `15.6.0` → `15.7.0-SNAPSHOT`
- `suggest.version`: `15.6.0` → `15.7.0-SNAPSHOT`

The `15.6.x` maintenance branch has been created prior to this change.

## Test plan

- [ ] `mvn -pl . -N validate` passes on this branch
- [ ] After merge, deploy `15.7.0-SNAPSHOT` to the Maven snapshot repository so downstream repos can consume it