### PR TITLE
chore(deps): update dependency versions and move gpg plugin to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,70 +61,70 @@
 		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>11.0.18</tomcat.version>
+		<tomcat.version>11.0.21</tomcat.version>
 		<tomcat.boot.version>3.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
-		<msal4j.version>1.24.0</msal4j.version>
+		<msal4j.version>1.24.1</msal4j.version>
 		<asm.version>9.9.1</asm.version>
 		<azure.core.version>1.57.1</azure.core.version>
 		<azure.identity.version>1.18.2</azure.identity.version>
 		<azure.core.http.netty.version>1.16.3</azure.core.http.netty.version>
-		<bouncycastle.version>1.83</bouncycastle.version>
-		<commonmark.version>0.27.1</commonmark.version>
+		<bouncycastle.version>1.84</bouncycastle.version>
+		<commonmark.version>0.28.0</commonmark.version>
 		<commons.codec.version>1.21.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M5</commons.fileupload.version>
-		<commons.io.version>2.21.0</commons.io.version>
+		<commons.io.version>2.22.0</commons.io.version>
 		<commons.lang3.version>3.20.0</commons.lang3.version>
-		<commons.net.version>3.12.0</commons.net.version>
+		<commons.net.version>3.13.0</commons.net.version>
 		<commons.pool2.version>2.13.1</commons.pool2.version>
 		<commons.text.version>1.15.0</commons.text.version>
 		<corelib.version>0.7.1</corelib.version>
 		<curl4j.version>1.3.2</curl4j.version>
-		<google.cloud.storage.version>2.64.0</google.cloud.storage.version>
+		<google.cloud.storage.version>2.67.0</google.cloud.storage.version>
 		<google.http.client.version>1.47.0</google.http.client.version>
 		<google.oauth.client.version>1.39.0</google.oauth.client.version>
-		<groovy.version>4.0.30</groovy.version>
-		<guava.version>33.5.0-jre</guava.version>
-		<handlebars.version>4.4.0</handlebars.version>
+		<groovy.version>4.0.31</groovy.version>
+		<guava.version>33.6.0-jre</guava.version>
+		<handlebars.version>4.5.0</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
-		<httpclient5.version>5.6</httpclient5.version>
-		<icu4j.version>78.2</icu4j.version>
-		<jackson.version>2.20.1</jackson.version>
-		<jackson.annotations.version>2.20</jackson.annotations.version>
+		<httpclient5.version>5.6.1</httpclient5.version>
+		<icu4j.version>78.3</icu4j.version>
+		<jackson.version>2.21.2</jackson.version>
+		<jackson.annotations.version>2.21</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<java.saml.version>3.1.0</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
-		<jakarta.mail.version>2.0.3</jakarta.mail.version>
+		<jakarta.mail.version>2.0.5</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
 		<jcifs.version>3.0.2</jcifs.version>
-		<jersey.common.version>3.1.10</jersey.common.version>
+		<jersey.common.version>3.1.11</jersey.common.version>
 		<jhighlight.version>2.0.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
-		<jodconverter.version>4.4.9</jodconverter.version>
+		<jodconverter.version>4.4.11</jodconverter.version>
 		<jakarta.jstl.api.version>3.0.2</jakarta.jstl.api.version>
 		<jakarta.jstl.version>3.0.1</jakarta.jstl.version>
 		<jakarta.transaction.version>2.0.1</jakarta.transaction.version>
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.25.3</log4j.version>
 		<log4j.ecs.version>1.7.0</log4j.ecs.version>
-		<lucene.version>10.3.2</lucene.version>
-		<microsoft.graph.version>6.62.0</microsoft.graph.version>
+		<lucene.version>10.4.0</lucene.version>
+		<microsoft.graph.version>6.63.0</microsoft.graph.version>
 		<minio.version>8.6.0</minio.version>
 		<nekohtml.version>3.0.3</nekohtml.version>
-		<oauth2.oidc.sdk.version>11.23</oauth2.oidc.sdk.version>
+		<oauth2.oidc.sdk.version>11.37</oauth2.oidc.sdk.version>
 		<okhttp.version>5.3.2</okhttp.version>
-		<pdfbox.version>3.0.6</pdfbox.version>
-		<playwright.version>1.58.0</playwright.version>
-		<poi.version>5.4.1</poi.version>
-		<s3.version>2.42.13</s3.version>
+		<pdfbox.version>3.0.7</pdfbox.version>
+		<playwright.version>1.59.0</playwright.version>
+		<poi.version>5.5.1</poi.version>
+		<s3.version>2.42.40</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.1</spnego.version>
-		<tika.version>3.2.3</tika.version>
+		<tika.version>3.3.0</tika.version>
 
 		<!-- Testing -->
 		<utflute.version>2.5.0</utflute.version>
@@ -138,15 +138,15 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-antrun-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.7.1</version>
+					<version>3.8.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.14.0</version>
+					<version>3.15.0</version>
 					<configuration>
 						<release>21</release>
 						<encoding>UTF-8</encoding>
@@ -154,15 +154,15 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.8.1</version>
+					<version>3.10.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>3.5.3</version>
+					<version>3.5.5</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.2</version>
+					<version>3.12.0</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<docencoding>UTF-8</docencoding>
@@ -182,7 +182,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.4.2</version>
+					<version>3.5.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jxr-plugin</artifactId>
@@ -190,11 +190,11 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.5.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.6.2</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-source-plugin</artifactId>
@@ -210,7 +210,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.3</version>
+					<version>3.5.5</version>
 					<configuration>
 						<useSystemClassLoader>false</useSystemClassLoader>
 					</configuration>
@@ -218,7 +218,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.13</version>
+					<version>0.8.14</version>
 					<executions>
 						<execution>
 							<goals>
@@ -236,7 +236,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.5.1</version>
 				</plugin>
 				<plugin>
 					<groupId>com.mycila</groupId>
@@ -270,7 +270,7 @@
 				<plugin>
 					<groupId>net.revelc.code.formatter</groupId>
 					<artifactId>formatter-maven-plugin</artifactId>
-					<version>2.26.0</version>
+					<version>2.29.0</version>
 					<executions>
 						<execution>
 							<goals>
@@ -285,7 +285,7 @@
 				<plugin>
 					<groupId>com.github.hazendaz.maven</groupId>
 					<artifactId>yuicompressor-maven-plugin</artifactId>
-					<version>2.2.0</version>
+					<version>2.3.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.dbflute</groupId>
@@ -295,7 +295,7 @@
 				<plugin>
 					<groupId>org.vafer</groupId>
 					<artifactId>jdeb</artifactId>
-					<version>1.13</version>
+					<version>1.14</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -305,20 +305,6 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.2.7</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
@@ -330,6 +316,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.2.8</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<bestPractices>true</bestPractices>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>codelibs.org</id>


### PR DESCRIPTION
## Summary
Routine maintenance update for fess-parent: bump library and Maven plugin versions, and isolate GPG signing into a dedicated `release` profile so normal builds no longer require a GPG key.

## Changes Made
- Updated library versions: tomcat 11.0.18→11.0.21, jackson 2.20.1→2.21.2, lucene 10.3.2→10.4.0, tika 3.2.3→3.3.0, poi 5.4.1→5.5.1, pdfbox 3.0.6→3.0.7, playwright 1.58.0→1.59.0, guava 33.5.0→33.6.0, groovy 4.0.30→4.0.31, handlebars 4.4.0→4.5.0, httpclient5 5.6→5.6.1, icu4j 78.2→78.3, commons-io 2.21.0→2.22.0, commons-net 3.12.0→3.13.0, google-cloud-storage 2.64.0→2.67.0, microsoft-graph 6.62.0→6.63.0, oauth2-oidc-sdk 11.23→11.37, jersey 3.1.10→3.1.11, jodconverter 4.4.9→4.4.11, jakarta-mail 2.0.3→2.0.5, bouncycastle 1.83→1.84, commonmark 0.27.1→0.28.0, msal4j 1.24.0→1.24.1, s3 2.42.13→2.42.40.
- Updated Maven plugin versions: compiler, dependency, failsafe, javadoc, jar, resources, shade, surefire, war, jacoco, antrun, assembly, formatter, yuicompressor, jdeb.
- Moved `maven-gpg-plugin` from the default `<build>` section into a new `release` profile, bumped to 3.2.8, and enabled `<bestPractices>true</bestPractices>`.

## Testing
- Downstream repos (fess-crawler, fess-suggest, fess, plugins) should build successfully with `mvn clean install -DskipTests` after this parent is installed locally.
- Release builds must be run with `-Prelease` to activate GPG signing.

## Breaking Changes
- Release builds now require activating the `release` profile (`mvn ... -Prelease`) for GPG signing. Non-release builds will skip signing, which is the intended new behavior.

## Additional Notes
- GPG plugin `bestPractices=true` enforces the modern GPG signing flow; confirm the release CI environment supports it.