### PR TITLE
build: activate release profile via maven-release-plugin releaseProfiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,13 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<releaseProfiles>release</releaseProfiles>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
 				<version>0.10.0</version>


### PR DESCRIPTION
## Summary
Wire the existing `release` profile into maven-release-plugin so release-only plugins (GPG signing) are activated automatically during `release:perform`, following the maven-release-plugin 2→3 migration guide (https://maven.apache.org/maven-release/maven-release-plugin/migrate.html).

## Changes Made
- Added maven-release-plugin 3.1.1 with `<releaseProfiles>release</releaseProfiles>` to the main build

## Testing
- `mvn install -N` succeeds without invoking GPG
- Effective POM confirms `releaseProfiles=release` is applied

## Additional Notes
- The same standardization is applied across other CodeLibs repositories (fesen-httpclient, corelib, curl4j, jcifs, jhighlight, nekohtml, spnego, java-saml).