### PR TITLE
chore(deps): update library and Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,9 +283,9 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>com.github.hazendaz.maven</groupId>
+					<groupId>org.codelibs.maven</groupId>
 					<artifactId>yuicompressor-maven-plugin</artifactId>
-					<version>2.4.0</version>
+					<version>2.0.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.dbflute</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,18 +61,18 @@
 		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
-		<tomcat.version>11.0.21</tomcat.version>
+		<tomcat.version>11.0.22</tomcat.version>
 		<tomcat.boot.version>3.0.0</tomcat.boot.version>
 
 		<!-- Partner Library -->
-		<msal4j.version>1.24.1</msal4j.version>
+		<msal4j.version>1.25.0</msal4j.version>
 		<asm.version>9.9.1</asm.version>
-		<azure.core.version>1.57.1</azure.core.version>
-		<azure.identity.version>1.18.2</azure.identity.version>
-		<azure.core.http.netty.version>1.16.3</azure.core.http.netty.version>
+		<azure.core.version>1.58.1</azure.core.version>
+		<azure.identity.version>1.18.4</azure.identity.version>
+		<azure.core.http.netty.version>1.16.5</azure.core.http.netty.version>
 		<bouncycastle.version>1.84</bouncycastle.version>
 		<commonmark.version>0.28.0</commonmark.version>
-		<commons.codec.version>1.21.0</commons.codec.version>
+		<commons.codec.version>1.22.0</commons.codec.version>
 		<commons.fileupload.version>2.0.0-M5</commons.fileupload.version>
 		<commons.io.version>2.22.0</commons.io.version>
 		<commons.lang3.version>3.20.0</commons.lang3.version>
@@ -81,12 +81,12 @@
 		<commons.text.version>1.15.0</commons.text.version>
 		<corelib.version>0.7.1</corelib.version>
 		<curl4j.version>1.3.2</curl4j.version>
-		<google.cloud.storage.version>2.67.0</google.cloud.storage.version>
+		<google.cloud.storage.version>2.69.0</google.cloud.storage.version>
 		<google.http.client.version>1.47.0</google.http.client.version>
 		<google.oauth.client.version>1.39.0</google.oauth.client.version>
-		<groovy.version>4.0.31</groovy.version>
+		<groovy.version>4.0.32</groovy.version>
 		<guava.version>33.6.0-jre</guava.version>
-		<handlebars.version>4.5.0</handlebars.version>
+		<handlebars.version>4.5.1</handlebars.version>
 		<httpcomponents.core.version>4.4.16</httpcomponents.core.version>
 		<httpcomponents.version>4.5.14</httpcomponents.version>
 		<httpclient5.version>5.6.1</httpclient5.version>
@@ -99,9 +99,9 @@
 		<jakarta.mail.version>2.0.5</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
-		<jbig2.imageio.version>3.0.4</jbig2.imageio.version>
+		<jbig2.imageio.version>3.0.5</jbig2.imageio.version>
 		<jcifs.version>3.0.2</jcifs.version>
-		<jersey.common.version>3.1.11</jersey.common.version>
+		<jersey.common.version>3.1.12</jersey.common.version>
 		<jhighlight.version>2.0.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
 		<jodconverter.version>4.4.11</jodconverter.version>
@@ -110,26 +110,26 @@
 		<jakarta.transaction.version>2.0.1</jakarta.transaction.version>
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.25.4</log4j.version>
-		<log4j.ecs.version>1.7.0</log4j.ecs.version>
+		<log4j.ecs.version>1.8.0</log4j.ecs.version>
 		<lucene.version>10.4.0</lucene.version>
-		<microsoft.graph.version>6.63.0</microsoft.graph.version>
+		<microsoft.graph.version>6.65.0</microsoft.graph.version>
 		<minio.version>8.6.0</minio.version>
 		<nekohtml.version>3.0.3</nekohtml.version>
-		<oauth2.oidc.sdk.version>11.37</oauth2.oidc.sdk.version>
-		<okhttp.version>5.3.2</okhttp.version>
+		<oauth2.oidc.sdk.version>11.37.2</oauth2.oidc.sdk.version>
+		<okhttp.version>5.4.0</okhttp.version>
 		<pdfbox.version>3.0.7</pdfbox.version>
-		<playwright.version>1.59.0</playwright.version>
+		<playwright.version>1.60.0</playwright.version>
 		<poi.version>5.5.1</poi.version>
-		<s3.version>2.42.40</s3.version>
+		<s3.version>2.46.9</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<spnego.version>1.2.1</spnego.version>
-		<tika.version>3.3.0</tika.version>
+		<tika.version>3.3.1</tika.version>
 
 		<!-- Testing -->
 		<utflute.version>2.5.0</utflute.version>
 		<junit.version>4.13.2</junit.version>
-		<junit.jupiter.version>5.12.2</junit.jupiter.version>
+		<junit.jupiter.version>5.14.4</junit.jupiter.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -154,11 +154,11 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.10.0</version>
+					<version>3.11.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>3.5.5</version>
+					<version>3.5.6</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
@@ -210,7 +210,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.5</version>
+					<version>3.5.6</version>
 					<configuration>
 						<useSystemClassLoader>false</useSystemClassLoader>
 					</configuration>
@@ -218,7 +218,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.14</version>
+					<version>0.8.15</version>
 					<executions>
 						<execution>
 							<goals>
@@ -285,7 +285,7 @@
 				<plugin>
 					<groupId>com.github.hazendaz.maven</groupId>
 					<artifactId>yuicompressor-maven-plugin</artifactId>
-					<version>2.3.1</version>
+					<version>2.4.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.dbflute</groupId>
@@ -307,7 +307,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.3.1</version>
 				<configuration>
 					<releaseProfiles>release</releaseProfiles>
 				</configuration>


### PR DESCRIPTION
## Summary

Routine dependency update for `pom.xml`: 19 library version properties and 6 Maven plugin versions, all latest stable releases verified against repo1.maven.org metadata.

### Library updates

| Property | Old | New |
|---|---|---|
| msal4j | 1.24.1 | 1.25.0 |
| azure.core | 1.57.1 | 1.58.1 |
| azure.identity | 1.18.2 | 1.18.4 |
| azure.core.http.netty | 1.16.3 | 1.16.5 |
| commons.codec | 1.21.0 | 1.22.0 |
| google.cloud.storage | 2.67.0 | 2.69.0 |
| groovy | 4.0.31 | 4.0.32 |
| handlebars | 4.5.0 | 4.5.1 |
| jbig2.imageio | 3.0.4 | 3.0.5 |
| jersey.common | 3.1.11 | 3.1.12 |
| log4j.ecs | 1.7.0 | 1.8.0 |
| microsoft.graph | 6.63.0 | 6.65.0 |
| oauth2.oidc.sdk | 11.37 | 11.37.2 |
| okhttp | 5.3.2 | 5.4.0 |
| playwright | 1.59.0 | 1.60.0 |
| s3 (AWS SDK) | 2.42.40 | 2.46.9 |
| tika | 3.3.0 | 3.3.1 |
| tomcat | 11.0.21 | 11.0.22 |
| junit.jupiter | 5.12.2 | 5.14.4 |

### Maven plugin updates

| Plugin | Old | New |
|---|---|---|
| maven-dependency-plugin | 3.10.0 | 3.11.0 |
| maven-failsafe-plugin | 3.5.5 | 3.5.6 |
| maven-surefire-plugin | 3.5.5 | 3.5.6 |
| jacoco-maven-plugin | 0.8.14 | 0.8.15 |
| yuicompressor-maven-plugin | com.github.hazendaz.maven 2.3.1 | org.codelibs.maven 2.0.0 |
| maven-release-plugin | 3.1.1 | 3.3.1 |

### Compatibility verification

- **yuicompressor-maven-plugin**: switched to the `org.codelibs.maven` fork, which is the groupId actually referenced by the fess build (`repos/fess/pom.xml` already uses `org.codelibs.maven:yuicompressor-maven-plugin:2.0.0`); the previous `com.github.hazendaz.maven` pluginManagement entry was unused.

- **Tika 3.3.1**: its parent POM pins poi 5.5.1, pdfbox 3.0.7, bouncycastle 1.84, and commons-codec 1.22.0 — all exactly matched after this update.
- **OpenSearch 3.7.0**: constrained versions (jackson 2.21.3, lucene 10.4.0, log4j 2.25.4, asm, httpcomponents, httpclient5) remain aligned and unchanged.
- **Deferred (major versions, out of scope)**: slf4j 2.x (needs log4j-slf4j2-impl bridge migration in a dedicated PR), google-http-client 2.x, groovy 5.x, jersey 4.x, minio 9.x, junit-jupiter 6.x. commons-fileupload stays at 2.0.0-M5 (no GA release yet).

## Test plan

Built with tests against the updated parent POM (all BUILD SUCCESS, zero failures):

- [x] fess-crawler
- [x] fess-crawler-playwright (186 tests)
- [x] fess-suggest (688 tests)
- [x] fess (6,184 tests)
- [x] fess-ds-microsoft365, fess-llm-openai, fess-llm-gemini, fess-llm-ollama (plugins consuming the updated Azure/MSAL/Graph/okhttp libraries)
