### PR TITLE
chore(release): bump versions to 15.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.7.0-SNAPSHOT</fess.version>
+		<fess.version>15.7.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.7.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.7.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.7.0</crawler.version>
+		<crawler.playwright.version>15.7.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.7.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.7.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.7.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary
Promotes the Fess ecosystem versions managed by this parent POM from `15.7.0-SNAPSHOT` to the `15.7.0` release.

## Changes Made
- `fess.version`: `15.7.0-SNAPSHOT` → `15.7.0`
- `crawler.version`: `15.7.0-SNAPSHOT` → `15.7.0`
- `crawler.playwright.version`: `15.7.0-SNAPSHOT` → `15.7.0`
- `suggest.version`: `15.7.0-SNAPSHOT` → `15.7.0`

## Testing
- No code changes; only POM property values. Verified the diff touches only the four version properties.

## Breaking Changes
- None.
