### PR TITLE
Update version to 15.8.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.fess</groupId>
 	<artifactId>fess-parent</artifactId>
-	<version>15.7.1-SNAPSHOT</version>
+	<version>15.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Fess</name>
 	<description>Fess is Full tExt Search System.</description>
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.7.0</fess.version>
+		<fess.version>15.8.0-SNAPSHOT</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.7.0</crawler.version>
-		<crawler.playwright.version>15.7.0</crawler.playwright.version>
+		<crawler.version>15.8.0-SNAPSHOT</crawler.version>
+		<crawler.playwright.version>15.8.0-SNAPSHOT</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.7.0</suggest.version>
+		<suggest.version>15.8.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.7.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary

Bump version for the 15.8.0 development cycle.

Depends on upstream Fess artifacts (`fess-parent`, and where applicable `fess-suggest`, `fess-crawler`, `fess-crawler-playwright`, `fess`) at `15.8.0-SNAPSHOT`, which must already be deployed to the Maven snapshot repository before CI runs here.

## Test plan

- [ ] CI build passes against `15.8.0-SNAPSHOT` upstreams