### PR TITLE
chore(deps): bump CodeLibs libraries to next development snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
 		<commons.net.version>3.13.0</commons.net.version>
 		<commons.pool2.version>2.13.1</commons.pool2.version>
 		<commons.text.version>1.15.0</commons.text.version>
-		<corelib.version>0.7.1</corelib.version>
-		<curl4j.version>1.3.2</curl4j.version>
+		<corelib.version>0.7.2-SNAPSHOT</corelib.version>
+		<curl4j.version>1.3.3-SNAPSHOT</curl4j.version>
 		<google.cloud.storage.version>2.69.0</google.cloud.storage.version>
 		<google.http.client.version>1.47.0</google.http.client.version>
 		<google.oauth.client.version>1.39.0</google.oauth.client.version>
@@ -94,13 +94,13 @@
 		<jackson.version>2.21.3</jackson.version>
 		<jackson.annotations.version>2.21</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
-		<java.saml.version>3.1.0</java.saml.version>
+		<java.saml.version>3.1.1-SNAPSHOT</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.5</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
 		<jakarta.transaction.api.version>2.0.1</jakarta.transaction.api.version>
 		<jbig2.imageio.version>3.0.5</jbig2.imageio.version>
-		<jcifs.version>3.0.2</jcifs.version>
+		<jcifs.version>3.0.3-SNAPSHOT</jcifs.version>
 		<jersey.common.version>3.1.12</jersey.common.version>
 		<jhighlight.version>2.0.0</jhighlight.version>
 		<jlha.version>0.06-05</jlha.version>
@@ -114,7 +114,7 @@
 		<lucene.version>10.4.0</lucene.version>
 		<microsoft.graph.version>6.65.0</microsoft.graph.version>
 		<minio.version>8.6.0</minio.version>
-		<nekohtml.version>3.0.3</nekohtml.version>
+		<nekohtml.version>3.0.4-SNAPSHOT</nekohtml.version>
 		<oauth2.oidc.sdk.version>11.37.2</oauth2.oidc.sdk.version>
 		<okhttp.version>5.4.0</okhttp.version>
 		<pdfbox.version>3.0.7</pdfbox.version>
@@ -123,7 +123,7 @@
 		<s3.version>2.46.9</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<spnego.version>1.2.1</spnego.version>
+		<spnego.version>1.2.2-SNAPSHOT</spnego.version>
 		<tika.version>3.3.1</tika.version>
 
 		<!-- Testing -->


### PR DESCRIPTION
## Summary

Point the CodeLibs-managed dependencies at their next development snapshot versions during 15.8.0 development, so Fess builds against the latest in-development changes of these sibling libraries.

| Library | Before | After |
|---|---|---|
| corelib | 0.7.1 | 0.7.2-SNAPSHOT |
| curl4j | 1.3.2 | 1.3.3-SNAPSHOT |
| java-saml | 3.1.0 | 3.1.1-SNAPSHOT |
| jcifs | 3.0.2 | 3.0.3-SNAPSHOT |
| nekohtml | 3.0.3 | 3.0.4-SNAPSHOT |
| spnego | 1.2.1 | 1.2.2-SNAPSHOT |

## Notes

- These are all CodeLibs-owned libraries published to the CodeLibs Maven repository.
- SNAPSHOT versions must be pinned back to release versions before the 15.8.0 release.