### PR TITLE
feat(build): deploy Fess plugins to maven.codelibs.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
+		<extensions>
+			<!-- Wagon provider for scp:// transport to maven.codelibs.org -->
+			<extension>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-ssh</artifactId>
+				<version>3.5.3</version>
+			</extension>
+		</extensions>
 		<pluginManagement>
 			<plugins>
 				<plugin>
@@ -302,6 +310,21 @@
 					<artifactId>rpm-maven-plugin</artifactId>
 					<version>2.3.0</version>
 				</plugin>
+				<!-- Declared here for version and configuration only. The repositories
+				     that publish to Maven Central (fess, fess-crawler,
+				     fess-crawler-playwright, fess-suggest) declare the plugin in their
+				     own build/plugins. Declaring it in build/plugins here would make
+				     every plugin inherit it, and its DeployLifecycleParticipant would
+				     disable maven-deploy-plugin, breaking deployment to
+				     maven.codelibs.org. -->
+				<plugin>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.11.0</version>
+					<configuration>
+						<publishingServerId>central</publishingServerId>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -312,14 +335,14 @@
 					<releaseProfiles>release</releaseProfiles>
 				</configuration>
 			</plugin>
+			<!-- fess-parent itself publishes to Maven Central. inherited=false keeps
+			     this out of child projects, so the plugins use the scp
+			     distributionManagement below instead. -->
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.11.0</version>
 				<extensions>true</extensions>
-				<configuration>
-					<publishingServerId>central</publishingServerId>
-				</configuration>
+				<inherited>false</inherited>
 			</plugin>
 		</plugins>
 	</build>
@@ -349,11 +372,39 @@
 			</build>
 		</profile>
 	</profiles>
+	<!-- Deployment target for the Fess plugins (fess-ds-*, fess-llm-*, fess-webapp-*,
+	     fess-script-*, fess-theme-*, fess-thumbnail-*, fess-ingest-*).
+	     This is unused by fess-parent itself and by fess / fess-crawler /
+	     fess-crawler-playwright / fess-suggest, because central-publishing-maven-plugin
+	     disables maven-deploy-plugin in those projects. -->
+	<distributionManagement>
+		<repository>
+			<id>codelibs-repo</id>
+			<name>CodeLibs Repository</name>
+			<url>scp://maven.codelibs.org/var/www/maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>codelibs-snapshots</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>scp://maven.codelibs.org/var/www/maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>codelibs.org</id>
 			<name>CodeLibs Repository</name>
-			<url>https://maven.codelibs.org/</url>
+			<url>https://maven.codelibs.org/release/</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>codelibs.org.snapshot</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>https://maven.codelibs.org/snapshot/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</pluginRepository>
 		<pluginRepository>
 			<id>central-portal-snapshots</id>
@@ -371,7 +422,18 @@
 		<repository>
 			<id>codelibs.org</id>
 			<name>CodeLibs Repository</name>
-			<url>https://maven.codelibs.org/</url>
+			<url>https://maven.codelibs.org/release/</url>
+		</repository>
+		<repository>
+			<id>codelibs.org.snapshot</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>https://maven.codelibs.org/snapshot/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
 		</repository>
 		<repository>
 			<id>central-portal-snapshots</id>


### PR DESCRIPTION
> **Superseded in part.** This PR's `distributionManagement` block was reverted by #62, and the
> `wagon-ssh` extension was replaced by `wagon-ssh-external` in #64. See those PRs for the
> reasoning. The change history is kept here for reference.

## Summary

Maven Central introduced an upload limit that makes it impractical to keep releasing the Fess
plugin artifacts there. This moved the plugin repositories to the CodeLibs repository, while
`fess-parent`, `fess`, `fess-crawler`, `fess-crawler-playwright` and `fess-suggest` stay on
Maven Central.

## Why the plugin POMs needed no change

`central-publishing-maven-plugin` was declared in `build/plugins` with `extensions=true`, so
every child inherited it. Its `DeployLifecycleParticipant` does this:

```
maybeSkipMavenDeployPlugin() -> getMavenDeployPlugin(model).getExecutions().clear()
setUpCentralPublishingExecution() -> id=injected-central-publishing, goal=publish, phase=deploy
```

It removes `maven-deploy-plugin`'s `default-deploy` at runtime, so adding
`distributionManagement` to a plugin POM alone has no effect.

`getCentralPublishingPlugin()` only scans `model.getBuild().getPlugins()` and never looks at
`pluginManagement`. Moving the declaration there means the participant no longer activates in
the plugin repositories. `fess-parent` itself keeps the Maven Central path via a re-declaration
with `inherited=false`.

## Changes

- Add a Wagon build extension for the CodeLibs repository transport
- Move `central-publishing-maven-plugin` from `build/plugins` to `pluginManagement`
- Re-declare it for `fess-parent` itself with `extensions=true` + `inherited=false`
- Add `distributionManagement` (**reverted in #62** — it is inherited unconditionally and a POM
  cannot exempt itself from what it declares, which broke SNAPSHOT deployment for the five
  projects that stay on Maven Central)
- Update the CodeLibs repository URLs to the new layout

## Verification

The presence of `Installing Central Publishing features` in the `mvn validate` log tells
whether the participant is active. It is emitted before the build runs, so this can be checked
without executing `deploy`.

- `fess-parent`: emitted (Maven Central path preserved)
- `fess-ds-git` (representative plugin, POM unchanged): no longer emitted
- Effective POM of `fess-ds-git`: no `central-publishing-maven-plugin` under `build/plugins`
- `mvn deploy -DaltDeploymentRepository=local::file://...` on `fess-ds-git` succeeds

> That last check used a `file://` target, so it never exercised the SSH transport. That gap is
> what allowed the two defects fixed in #62 and #64 to reach `main`.
