### PR TITLE
fix(build): repair the deployment setup added in #61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,23 +372,15 @@
 			</build>
 		</profile>
 	</profiles>
-	<!-- Deployment target for the Fess plugins (fess-ds-*, fess-llm-*, fess-webapp-*,
-	     fess-script-*, fess-theme-*, fess-thumbnail-*, fess-ingest-*).
-	     This is unused by fess-parent itself and by fess / fess-crawler /
-	     fess-crawler-playwright / fess-suggest, because central-publishing-maven-plugin
-	     disables maven-deploy-plugin in those projects. -->
-	<distributionManagement>
-		<repository>
-			<id>codelibs-repo</id>
-			<name>CodeLibs Repository</name>
-			<url>scp://maven.codelibs.org/var/www/maven/release</url>
-		</repository>
-		<snapshotRepository>
-			<id>codelibs-snapshots</id>
-			<name>CodeLibs Snapshot Repository</name>
-			<url>scp://maven.codelibs.org/var/www/maven/snapshot</url>
-		</snapshotRepository>
-	</distributionManagement>
+	<!-- No distributionManagement here on purpose. It is inherited unconditionally and a
+	     POM cannot exempt itself from what it declares, so declaring the CodeLibs
+	     repositories here would also redirect the SNAPSHOT deployments of fess-parent,
+	     fess, fess-crawler, fess-crawler-playwright and fess-suggest, which must stay on
+	     Maven Central: central-publishing-maven-plugin resolves SNAPSHOT deployments
+	     through project.getDistributionManagementArtifactRepository() and only falls back
+	     to centralSnapshotsUrl when it is absent. Each Fess plugin declares the CodeLibs
+	     repositories in its own POM instead. The wagon-ssh build extension above is
+	     inherited and provides the scp transport those plugins need. -->
 	<pluginRepositories>
 		<pluginRepository>
 			<id>codelibs.org</id>


### PR DESCRIPTION
## Problem

Two defects introduced by #61. This PR fixes the first; the second is fixed in #64.

### 1. distributionManagement redirected Maven Central SNAPSHOT deployments

`fess-parent`, `fess`, `fess-crawler`, `fess-crawler-playwright` and `fess-suggest` all started
failing their SNAPSHOT deployment.

#61 assumed `distributionManagement` was unused in those projects because
`central-publishing-maven-plugin` disables `maven-deploy-plugin`. **That holds for releases
only.** For SNAPSHOTs the plugin deploys the artifacts itself:

```java
// ArtifactDeferrerImpl.getDeploymentRepository
session.getCurrentProject().getDistributionManagementArtifactRepository()   // consulted first
// falls back to https://central.sonatype.com/repository/maven-snapshots/ only when absent
```

`PublishMojo.postProcessSnapshot` passes a `null` repository, so the deferrer resolves it from
the project. Every project inheriting `fess-parent` therefore pointed its SNAPSHOTs at the
CodeLibs repository.

### 2. wagon-ssh cannot read modern SSH keys

Fixed separately in #64.

## Fix

Remove `distributionManagement`. It is inherited unconditionally and a POM cannot exempt itself
from what it declares, so this cannot be scoped from `fess-parent`. Each Fess plugin declares
the CodeLibs repositories in its own POM instead (companion PRs). This restores `fess-parent`
and the four Maven Central projects to exactly their pre-#61 behaviour.

## Verification

| project | `project.distributionManagement.snapshotRepository.url` |
|---|---|
| fess-parent | null (falls back to Central Portal snapshots) |
| fess | null |
| fess-crawler | null |
| fess-crawler-playwright | null |
| fess-suggest | null |

`Installing Central Publishing features` is still logged for `fess-parent` and the four Maven
Central projects, and still absent for the plugin repositories.
