### PR TITLE
chore(build): bump maven-jar-plugin and license-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.5.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jxr-plugin</artifactId>
@@ -249,7 +249,7 @@
 				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
-					<version>5.0.0</version>
+					<version>5.1.1</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<properties>


### PR DESCRIPTION
## Summary

Bump the build plugins that are behind the latest release on Maven Central.

| plugin | from | to |
|---|---|---|
| maven-jar-plugin | 3.5.0 | 3.5.1 |
| license-maven-plugin | 5.0.0 | 5.1.1 |

Every other build plugin — antrun, assembly, compiler, dependency, failsafe, javadoc, jxr,
resources, shade, surefire, war, release, gpg, jacoco, formatter, yuicompressor, dbflute, jdeb,
rpm, central-publishing — and the `wagon-ssh` extension are already at the latest release.

`maven-source-plugin` is deliberately left at 3.2.1; the POM already carries the MSOURCES-143
note explaining why.

## Verification

- `mvn install` on fess-parent succeeds
- `mvn install -DskipTests` on fess-ds-git runs `jar:3.5.1:jar` and `license:5.1.1:check`
  ("Checking licenses..." / BUILD SUCCESS), so both bumped plugins are actually exercised
- `mvn package -DskipTests` on fess-crawler (4 modules) succeeds
