### PR TITLE
fix(build): use wagon-ssh-external so modern SSH keys work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,10 +135,16 @@
 	</properties>
 	<build>
 		<extensions>
-			<!-- Wagon provider for scp:// transport to maven.codelibs.org -->
+			<!-- Wagon provider for scpexe:// transport to maven.codelibs.org. This drives the
+			     external ssh and scp commands rather than an embedded SSH client, so key
+			     handling follows the system OpenSSH configuration: ed25519 keys, the OpenSSH
+			     key file format, ssh-agent and ~/.ssh/config all work. The embedded
+			     alternative, wagon-ssh, depends on com.jcraft:jsch 0.1.55, whose only key
+			     types are DSA, ECDSA, RSA and PKCS8; anything else is rejected with
+			     "invalid privatekey" before a connection is even attempted. -->
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ssh</artifactId>
+				<artifactId>wagon-ssh-external</artifactId>
 				<version>3.5.3</version>
 			</extension>
 		</extensions>
@@ -379,8 +385,8 @@
 	     Maven Central: central-publishing-maven-plugin resolves SNAPSHOT deployments
 	     through project.getDistributionManagementArtifactRepository() and only falls back
 	     to centralSnapshotsUrl when it is absent. Each Fess plugin declares the CodeLibs
-	     repositories in its own POM instead. The wagon-ssh build extension above is
-	     inherited and provides the scp transport those plugins need. -->
+	     repositories in its own POM instead. The wagon-ssh-external build extension
+	     above is inherited and provides the scpexe transport those plugins need. -->
 	<pluginRepositories>
 		<pluginRepository>
 			<id>codelibs.org</id>


### PR DESCRIPTION
## Problem

`wagon-ssh` cannot read modern SSH keys. It depends on `com.jcraft:jsch` 0.1.55 — the final
release of that project — whose only key types are DSA, ECDSA, RSA and PKCS8. An ed25519 key,
or any key stored in the OpenSSH key file format, is rejected before a connection is even
attempted:

```
Cannot connect. Reason: invalid privatekey
```

## Why jsch cannot simply be replaced

The `extension` element accepts only `groupId`, `artifactId` and `version`, so the transitive
jsch dependency cannot be excluded. The extension realm also resolves classes self-first, so it
cannot be overridden from outside. Both workarounds were tried and both still failed with
`invalid privatekey`:

- declaring a maintained jsch fork as an additional build extension
- putting that fork on the core extension classpath via `-Dmaven.ext.class.path`

## Fix

Switch to `wagon-ssh-external`, which has no jsch dependency and delegates to the platform SSH
client. Key handling then follows the local OpenSSH configuration, so ed25519 keys, the OpenSSH
key file format, ssh-agent and `~/.ssh/config` all work. It serves `scpexe://` URLs, which the
Fess plugin POMs now use.

## Verification

- A standalone probe isolates the cause: `com.jcraft:jsch` 0.1.55 fails to load an ed25519 key
  with `invalid privatekey`, while a jsch fork that supports ed25519 loads the same file — so
  the key type, not the file, is the problem.
- `mvn install` on fess-parent succeeds.
- With this change installed, `mvn deploy` on `fess-ds-git` (which declares a `scpexe://`
  `distributionManagement`) runs `maven-deploy-plugin:3.1.4:deploy` and hands the transfer to
  the platform SSH client. Neither `invalid privatekey` nor `Unsupported transport protocol`
  appears.

The transfer itself was not completed, because the verification environment has no route to the
repository host.

## Merge order

This must be merged **before** the plugin PRs that declare `scpexe://` URLs, otherwise their
deployment fails with `Unsupported transport protocol scpexe`.

## Note for whoever runs the deployment

`settings.xml` needs `codelibs-repo` / `codelibs-snapshots` server entries.
