### PR TITLE
chore(deps): base on OpenSearch 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,11 @@
 		<suggest.version>15.8.0-SNAPSHOT</suggest.version>
 
 		<!-- Fesen -->
-		<fesen.httpclient.version>3.7.1-SNAPSHOT</fesen.httpclient.version>
+		<fesen.httpclient.version>3.8.0-SNAPSHOT</fesen.httpclient.version>
 
 		<!-- OpenSearch -->
-		<opensearch.version>3.7.0</opensearch.version>
-		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
+		<opensearch.version>3.8.0</opensearch.version>
+		<opensearch.runner.version>3.8.0.0</opensearch.runner.version>
 
 		<!-- Tomcat -->
 		<tomcat.version>11.0.22</tomcat.version>
@@ -91,8 +91,8 @@
 		<httpcomponents.version>4.5.14</httpcomponents.version>
 		<httpclient5.version>5.6.1</httpclient5.version>
 		<icu4j.version>78.3</icu4j.version>
-		<jackson.version>2.21.3</jackson.version>
-		<jackson.annotations.version>2.21</jackson.annotations.version>
+		<jackson.version>2.22.1</jackson.version>
+		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
 		<java.saml.version>3.1.1-SNAPSHOT</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
@@ -111,7 +111,7 @@
 		<kryo.version>5.6.2</kryo.version>
 		<log4j.version>2.25.4</log4j.version>
 		<log4j.ecs.version>1.8.0</log4j.ecs.version>
-		<lucene.version>10.4.0</lucene.version>
+		<lucene.version>10.5.0</lucene.version>
 		<microsoft.graph.version>6.65.0</microsoft.graph.version>
 		<minio.version>8.6.0</minio.version>
 		<nekohtml.version>3.0.4-SNAPSHOT</nekohtml.version>


### PR DESCRIPTION
## Summary

Move the dependency baseline to OpenSearch 3.8.0.

| Property | Before | After |
| --- | --- | --- |
| `opensearch.version` | 3.7.0 | 3.8.0 |
| `opensearch.runner.version` | 3.7.0.0 | 3.8.0.0 |
| `fesen.httpclient.version` | 3.7.1-SNAPSHOT | 3.8.0-SNAPSHOT |
| `lucene.version` | 10.4.0 | 10.5.0 |
| `jackson.version` | 2.21.3 | 2.22.1 |
| `jackson.annotations.version` | 2.21 | 2.22 |

Lucene and Jackson are not independent choices here. The OpenSearch 3.8.0 POM
pins `lucene-core` at 10.5.0 and `jackson-core` at 2.22.1, and Fess embeds
OpenSearch, so leaving them behind would put two versions of the same library on
one classpath. Jackson publishes `jackson-annotations` at minor granularity, so
the matching annotations release is 2.22 — there is no 2.22.1.

`log4j` is already at 2.25.4, which is what OpenSearch 3.8.0 uses, and is
unchanged.

## Verification

Built and tested downstream against this POM:

| Repository | Result |
| --- | --- |
| fesen-httpclient | 624 tests, 0 failures |
| fess-crawler | 2051 tests (see note) |
| fess-crawler-lasta / fess-crawler-opensearch | 15 / 40 tests, 0 failures |
| fess-suggest | 688 tests, 0 failures |
| fess | 6891 tests, 0 failures |

A running OpenSearch 3.8.0 node reports `lucene_version: 10.5.0`, which confirms
the Lucene bump matches the engine rather than just the POM.

Note: `Hc4HttpClientTest#test_doHead_accessTimeoutTarget` and its Hc5 sibling
fail intermittently under load. They assert a 1-second access timeout against a
2-second sleep; a different one of the two failed on each full run, and both pass
in isolation. Neither exercises any dependency changed here.

## Merge order

fesen-httpclient 3.8.0-SNAPSHOT is already published to the Maven snapshot
repository, so this can merge on its own. codelibs/fess needs a matching change
for the OpenSearch plugin and module literals it hardcodes.
