### PR TITLE
docs(build): clarify why fess-parent stays on Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Maven parent POM for [Fess](https://fess.codelibs.org/) (Full tExt Search Sy
 - Managed versions for the framework, search engine, and third-party libraries used throughout Fess
 - A shared set of Maven plugins pinned to known-good versions
 - Common build settings such as the Java release level, source encoding, license-header enforcement, and code formatting
-- Artifact signing and Maven Central publishing configuration for releases
+- Artifact signing, plus the `scpexe` wagon used to publish releases to the CodeLibs Maven repository
 
 Keeping these definitions in one place ensures compatible versions across modules and reduces the effort of upgrading dependencies.
 
@@ -38,7 +38,7 @@ Dependency and plugin versions are exposed as Maven properties (for example `${l
 
 ### Snapshots
 
-Development snapshots are published to the CodeLibs and Central Portal snapshot repositories, both already configured in this POM. Released artifacts are available from Maven Central.
+Snapshots of `fess-parent` itself are published to the Central Portal snapshot repository; snapshots of the modules that inherit from it are published to the CodeLibs snapshot repository. Both, along with the CodeLibs release repository, are already configured in this POM, so child modules resolve them without extra setup.
 
 ## Build
 
@@ -69,7 +69,8 @@ The plugin and build configuration defined here (compiler, Surefire/Failsafe, Ja
 Releases follow semantic versioning (`major.minor.patch`) and are produced with the Maven Release Plugin:
 
 1. Artifacts are signed with GPG under the `release` profile.
-2. They are published to Maven Central through the Central Publishing Plugin.
+2. `fess-parent` itself is published to Maven Central through the Central Publishing Plugin. It stays there deliberately: a parent POM can only be fetched from repositories the consuming project already knows about, so keeping it on Maven Central lets every child — including third-party plugins — resolve it without configuring an extra repository first.
+3. Every module inheriting from this POM publishes to the CodeLibs Maven repository over `scpexe`, using the `distributionManagement` declared in its own POM.
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -316,13 +316,11 @@
 					<artifactId>rpm-maven-plugin</artifactId>
 					<version>2.3.0</version>
 				</plugin>
-				<!-- Declared here for version and configuration only. The repositories
-				     that publish to Maven Central (fess, fess-crawler,
-				     fess-crawler-playwright, fess-suggest) declare the plugin in their
-				     own build/plugins. Declaring it in build/plugins here would make
-				     every plugin inherit it, and its DeployLifecycleParticipant would
-				     disable maven-deploy-plugin, breaking deployment to
-				     maven.codelibs.org. -->
+				<!-- Declared here for version and configuration only, so that the
+				     inherited=false declaration in build/plugins below picks them up.
+				     Declaring it in build/plugins here would make every child inherit
+				     it, and its DeployLifecycleParticipant would disable
+				     maven-deploy-plugin, breaking deployment to maven.codelibs.org. -->
 				<plugin>
 					<groupId>org.sonatype.central</groupId>
 					<artifactId>central-publishing-maven-plugin</artifactId>
@@ -341,9 +339,14 @@
 					<releaseProfiles>release</releaseProfiles>
 				</configuration>
 			</plugin>
-			<!-- fess-parent itself publishes to Maven Central. inherited=false keeps
-			     this out of child projects, so the plugins use the scp
-			     distributionManagement below instead. -->
+			<!-- fess-parent itself publishes to Maven Central. It is the one artifact
+			     in the Fess ecosystem that has to stay there: a POM can only be
+			     resolved from repositories a project already knows about, and the
+			     CodeLibs repositories this POM declares are not visible until this POM
+			     has been read. Keeping it on Maven Central lets every child - including
+			     third-party plugins - resolve the parent without extra configuration.
+			     inherited=false keeps the plugin out of child projects, so they use
+			     their own scp distributionManagement instead. -->
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
@@ -380,13 +383,13 @@
 	</profiles>
 	<!-- No distributionManagement here on purpose. It is inherited unconditionally and a
 	     POM cannot exempt itself from what it declares, so declaring the CodeLibs
-	     repositories here would also redirect the SNAPSHOT deployments of fess-parent,
-	     fess, fess-crawler, fess-crawler-playwright and fess-suggest, which must stay on
-	     Maven Central: central-publishing-maven-plugin resolves SNAPSHOT deployments
-	     through project.getDistributionManagementArtifactRepository() and only falls back
-	     to centralSnapshotsUrl when it is absent. Each Fess plugin declares the CodeLibs
+	     repositories here would also redirect the SNAPSHOT deployments of fess-parent
+	     itself, which must stay on Maven Central: central-publishing-maven-plugin
+	     resolves SNAPSHOT deployments through
+	     project.getDistributionManagementArtifactRepository() and only falls back to
+	     centralSnapshotsUrl when it is absent. Every child project declares the CodeLibs
 	     repositories in its own POM instead. The wagon-ssh-external build extension
-	     above is inherited and provides the scpexe transport those plugins need. -->
+	     above is inherited and provides the scpexe transport they need. -->
 	<pluginRepositories>
 		<pluginRepository>
 			<id>codelibs.org</id>


### PR DESCRIPTION
## Summary

`fess`, `fess-crawler`, `fess-crawler-playwright` and `fess-suggest` are moving off Maven Central to `maven.codelibs.org`, joining the Fess plugins. This PR updates `fess-parent` to match — comments and README only, no functional change.

`fess-parent` itself **stays on Maven Central**, deliberately.

## Why fess-parent cannot move

A parent POM is only resolvable from repositories the consuming project already knows about. The CodeLibs repositories declared in this POM are not visible until this POM has been read, so moving `fess-parent` would force every project that inherits from it — 35 in the CodeLibs org, plus every third-party Fess plugin — to add the repository to its own `<repositories>` first, or fail with `Non-resolvable parent POM`.

Verified with a minimal POM whose only parent is `fess-parent:15.8.0-SNAPSHOT`:

- with a `<repositories>` entry covering the parent's snapshots: `BUILD SUCCESS`
- without it: `Non-resolvable parent POM ... Could not find artifact org.codelibs.fess:fess-parent:pom:15.8.0-SNAPSHOT`

Keeping `fess-parent` on Maven Central makes it the bootstrap anchor, and no child needs to change. Artifact resolution is unaffected — children already inherit the CodeLibs release and snapshot repositories from this POM's `<repositories>`, confirmed in the effective POM.

`<distributionManagement>` still cannot live here: it is inherited unconditionally and a POM cannot exempt itself from what it declares, so it would redirect `fess-parent`'s own deployments too. Each child continues to declare it.

## Changes

- `pom.xml`: refresh the three comments that described the old split; explain the bootstrap constraint at the `central-publishing-maven-plugin` declaration
- `README.md`: correct what children inherit, which snapshot repository each side uses, and the release steps

## Verification

`mvn -B validate` still reports `Installing Central Publishing features`, so the Central publishing path remains active for this POM.
