### PR TITLE
chore(deps): keep spnego on 1.2.1 for 15.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 		<s3.version>2.46.9</s3.version>
 		<sai.version>0.3.0</sai.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<spnego.version>1.2.2-SNAPSHOT</spnego.version>
+		<spnego.version>1.2.1</spnego.version>
 		<tika.version>3.3.1</tika.version>
 
 		<!-- Testing -->


### PR DESCRIPTION
15.8 does not adopt spnego 1.2.2, so point at the last release rather than an unreleased
snapshot.

## Why not stay on the snapshot

The published `1.2.2-SNAPSHOT` (`1.2.2-20260705.013940-14`) cannot initialize with the
configuration Fess passes it. `SpnegoFilterConfig` resolves `spnego.login.conf` with:

```java
final File file = new File(new URI(loginconf));
```

`File(URI)` requires an absolute `file:` URI, while Fess supplies an absolute path from
`ResourceUtil.getResourceAsFileNoException(...).getAbsolutePath()`. The call used to sit
behind `assert` and was therefore skipped under the normal production setting; making it
unconditional turned it into an initialization failure, so every SPNEGO login ends in
`SsoLoginException: Failed to initialize SPNEGO.`

Reproduced with a `FilterConfig` that mirrors Fess's `SpnegoConfig`, assertions disabled:

```
===== spnego 1.2.1 =====
OK -> allowBasic=true; allowUnsecure=false; allowDelegation=false; allowLocalhost=false;
      canUseKeyTab=true; excludeDirs=null; username=

===== spnego 1.2.2-SNAPSHOT =====
THREW: java.lang.IllegalArgumentException: URI is not absolute
```

codelibs/spnego#26 fixes this on spnego master.

## Compatibility with 1.2.1

Everything Fess calls exists in 1.2.1 with the same signature:

- `SpnegoAuthenticator.getServerRealm()` — present since 2018, used by the realm allow list
- `SpnegoAuthenticator.dispose()` and `authenticate(HttpServletRequest, SpnegoHttpServletResponse)`
- `SpnegoFilterConfig.getInstance(FilterConfig)`
- `getExcludeDirs()` tolerates the `null` that Fess returns for `spnego.exclude.dirs`
- `setLogLevel` has `case 7`, so the quiet level Fess selects still maps to SEVERE

Verified against the repository: `mvn -Dspnego.version=1.2.1 dependency:tree` resolves
`org.codelibs:spnego:jar:1.2.1`, Fess compiles, and `SpnegoAuthenticatorTest` is green
(19 tests, no failures).

## What 15.8 gives up

The Fess-relevant parts of the 1.2.2 hardening (codelibs/spnego#23) that do not ship:

- UTF-8 decoding of the Basic authentication token
- removal of `password.hashCode()` from the FINE log and token redaction in
  `SpnegoAuthScheme.toString()`
- login module validation no longer gated on assertions

The fail-secure defaults from that change are **not** a loss: Fess passes an explicit value
for every one of `spnego.allow.basic`, `allow.unsecure.basic`, `prompt.ntlm`,
`allow.localhost` and `allow.delegation`, so the library defaults never apply. The repro
output above confirms it — `allowLocalhost=false` under 1.2.1 comes from Fess, not the
library.
