### PR TITLE
chore(deps): bump java-saml to 3.1.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 		<jackson.version>2.22.1</jackson.version>
 		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
-		<java.saml.version>3.1.1</java.saml.version>
+		<java.saml.version>3.1.2-SNAPSHOT</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.5</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>


### PR DESCRIPTION
## Summary
Bumps the `java.saml.version` property to the next development snapshot.

## Changes Made
- `pom.xml`: `java.saml.version` `3.1.1` → `3.1.2-SNAPSHOT`

## Testing
- N/A (version property change only)

## Breaking Changes
- None

## Additional Notes
- This moves `java-saml` back to a SNAPSHOT build, following up on #68 which had pinned it to the `3.1.1` release. Should be re-pinned to a released `3.1.2` once available.
