### PR TITLE
chore(deps): pin java-saml to released 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 		<jackson.version>2.22.1</jackson.version>
 		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<jai.imageio.version>1.4.0</jai.imageio.version>
-		<java.saml.version>3.1.2-SNAPSHOT</java.saml.version>
+		<java.saml.version>3.1.2</java.saml.version>
 		<jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
 		<jakarta.mail.version>2.0.5</jakarta.mail.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>


### PR DESCRIPTION
## Summary
Pin `java.saml.version` back to the released `3.1.2` artifact now that it's published on Maven Central, instead of tracking the `3.1.2-SNAPSHOT` development build.

## Changes Made
- `pom.xml`: `java.saml.version` changed from `3.1.2-SNAPSHOT` to `3.1.2`

## Testing
- No code changes beyond the version property; relies on the existing build to resolve the released artifact.

## Breaking Changes
- None

## Additional Notes
- This keeps `fess-parent` pinned to released artifacts, consistent with #68, now that the java-saml 3.1.2 release (tracked ahead of time in #69) is available.
