### PR TITLE
chore(deps): pin fess-parent to released 15.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<fess.version>15.8.0-SNAPSHOT</fess.version>
+		<fess.version>15.8.0</fess.version>
 
 		<!-- Main Framework -->
 		<dbflute.version>1.3.1</dbflute.version>
@@ -47,11 +47,11 @@
 		<mailflute.version>2.0.0</mailflute.version>
 
 		<!-- Crawler -->
-		<crawler.version>15.8.0-SNAPSHOT</crawler.version>
-		<crawler.playwright.version>15.8.0-SNAPSHOT</crawler.playwright.version>
+		<crawler.version>15.8.0</crawler.version>
+		<crawler.playwright.version>15.8.0</crawler.playwright.version>
 
 		<!-- Suggest -->
-		<suggest.version>15.8.0-SNAPSHOT</suggest.version>
+		<suggest.version>15.8.0</suggest.version>
 
 		<!-- Fesen -->
 		<fesen.httpclient.version>3.8.0</fesen.httpclient.version>


### PR DESCRIPTION
## Summary
Pins the remaining `-SNAPSHOT` versions in `fess-parent`'s POM to their released `15.8.0` counterparts, continuing the cleanup started in #68/#69/#70.

## Changes Made
- `fess.version`: `15.8.0-SNAPSHOT` → `15.8.0`
- `crawler.version`: `15.8.0-SNAPSHOT` → `15.8.0`
- `crawler.playwright.version`: `15.8.0-SNAPSHOT` → `15.8.0`
- `suggest.version`: `15.8.0-SNAPSHOT` → `15.8.0`

## Testing
- N/A (version property change only; no code changes)

## Breaking Changes
- None

## Additional Notes
- Keeps `fess-parent` consistent with the released artifact set on Maven Central rather than depending on SNAPSHOT builds.
